### PR TITLE
docs: credit Jeff Dickey (@jdx) as author on the README, spec, and site

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ no per-vendor logic and no registry entry.
 Site and specification: [packslip.dev](https://packslip.dev) ·
 [release/v1](https://packslip.dev/release/v1/)
 
+Created by [Jeff Dickey (@jdx)](https://github.com/jdx), the author of
+[mise](https://mise.jdx.dev) and [usage](https://usage.jdx.dev).
+
 ## In a GitHub release job
 
 ```yaml
@@ -92,4 +95,4 @@ Run `mise x hugo@0.165.0 -- hugo server` to preview the site locally. The
 Pages workflow fetches the current GitHub star count into `data/github.json`
 before building, so visitors receive it in the rendered HTML.
 
-MIT licensed.
+MIT licensed. Copyright (c) 2026 Jeff Dickey (@jdx).

--- a/docs/spec/packslip.md
+++ b/docs/spec/packslip.md
@@ -3,6 +3,8 @@
 Version 1, draft. Predicate types `https://packslip.dev/release/v1` and
 `https://packslip.dev/releases/v1`.
 
+Author: Jeff Dickey ([@jdx](https://github.com/jdx)).
+
 ## Goal
 
 A vendor publishes one signed, machine-readable document per release that

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -48,7 +48,7 @@
   <p class="notice" style="margin-top:0;margin-bottom:1.5rem"><strong>Work-in-progress proposal.</strong> This is a version 1 draft, not an adopted standard: it is far from certain that mise or Omarchy will adopt it. It still changes between releases; expect breaking changes until it is declared stable.</p>
   <span class="eyebrow">Specification</span>
   <h1>packslip: a signed release manifest</h1>
-  <p class="meta">Version 1, draft. Predicate types <code>https://packslip.dev/release/v1</code> and <code>https://packslip.dev/releases/v1</code>. The canonical text is <a href="https://github.com/jdx/packslip/blob/main/docs/spec/packslip.md"><code>docs/spec/packslip.md</code></a> in jdx/packslip; this page renders it with a field reference added. Schemas: <a href="/schema/release-v1.json"><code>release-v1.json</code></a>, <a href="/schema/releases-v1.json"><code>releases-v1.json</code></a>.</p>
+  <p class="meta">Version 1, draft. Author: <a href="https://github.com/jdx">Jeff Dickey (@jdx)</a>. Predicate types <code>https://packslip.dev/release/v1</code> and <code>https://packslip.dev/releases/v1</code>. The canonical text is <a href="https://github.com/jdx/packslip/blob/main/docs/spec/packslip.md"><code>docs/spec/packslip.md</code></a> in jdx/packslip; this page renders it with a field reference added. Schemas: <a href="/schema/release-v1.json"><code>release-v1.json</code></a>, <a href="/schema/releases-v1.json"><code>releases-v1.json</code></a>.</p>
 
   <h2 id="goal">Goal</h2>
   <p>A vendor publishes one signed, machine-readable document per release that says what the artifacts are and how to verify them. Any consumer (mise, omapac and the Omarchy Package Repository, aqua, Homebrew, a corporate mirror) verifies it against a single pinned identity or key and gets checksums, platform mapping, executables, provenance links, and what else ships with them (completions, man pages, a CLI spec, a skill, a desktop entry), without per-vendor logic and without a registry entry. The name is neutral on purpose: a packing slip is the paper in the box listing exactly what shipped.</p>
@@ -306,7 +306,7 @@
 </main>
 
 <footer class="wrap">
-  <span>packslip · version 1, draft · MIT licensed</span>
+  <span>packslip · version 1, draft · MIT licensed · by <a href="https://github.com/jdx">Jeff Dickey (@jdx)</a></span>
   <nav>
     <a href="/">Overview</a>
     <a href="/schema/release-v1.json">JSON schema</a>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -43,6 +43,7 @@
       <a class="btn primary" href="#vendors">Add it to a release job</a>
       <a class="btn" href="/release/v1/">Read the spec</a>
     </div>
+    <p class="byline">By <a href="https://github.com/jdx">Jeff Dickey (@jdx)</a>, author of <a href="https://mise.jdx.dev">mise</a>.</p>
   </div>
 
   <div class="slip" aria-label="Example packslip statement">
@@ -260,7 +261,7 @@ packslip releases --project mytool.example.com \
 </main>
 
 <footer class="wrap">
-  <span>packslip · version 1, draft · MIT licensed</span>
+  <span>packslip · version 1, draft · MIT licensed · by <a href="https://github.com/jdx">Jeff Dickey (@jdx)</a></span>
   <nav>
     <a href="/release/v1/">Specification</a>
     <a href="/schema/release-v1.json">JSON schema</a>

--- a/static/style.css
+++ b/static/style.css
@@ -174,6 +174,13 @@ pre code { background: none; padding: 0; font-size: inherit; }
   max-width: 34ch;
 }
 
+.hero .byline {
+  margin: 1.4rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+.hero .byline a { color: var(--ink-2); }
+
 .eyebrow {
   display: inline-block;
   font-family: var(--mono);


### PR DESCRIPTION
Credits the author prominently on every reader-facing surface. Cargo.toml, action.yml, the CLI's author field, and the LICENSE already named Jeff Dickey, so those are unchanged.

- README: a byline under the site links, and a copyright line with the license.
- Spec (`docs/spec/packslip.md`): an author line under the version line.
- Site overview (`layouts/index.html`): a byline in the hero under the call-to-action buttons, plus the footer.
- Spec page (`layouts/_default/single.html`): the meta line and the footer.
- `static/style.css`: a muted `.hero .byline` style.

Rebased onto the Hugo migration; git carried the site edits across the renames. Hugo is not available locally, so the site build is left to the Pages workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and static site copy only; no runtime, security, or format changes.
> 
> **Overview**
> Adds **Jeff Dickey (@jdx)** attribution on reader-facing surfaces that previously only said “MIT licensed,” aligning them with author metadata already in `Cargo.toml`, `action.yml`, and `LICENSE`.
> 
> The **README** gets a short byline (with links to mise and usage) after the packslip.dev links, and the license line now includes **Copyright (c) 2026 Jeff Dickey (@jdx)**. The canonical **spec** (`docs/spec/packslip.md`) adds an **Author** line under the version header.
> 
> On **packslip.dev**, the home page hero gains a muted **`.byline`** (styled in `static/style.css`), and both the overview and spec layouts show the author in the **meta/footer**. No tooling, schema, or verification behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24efc4b32f5340c0cc3ffda4d4ed2a90d7b8d23c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->