### PR TITLE
fix(site): render numeric star count

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,7 +36,12 @@ jobs:
       - id: pages
         uses: actions/configure-pages@v5
       - name: Build site
-        run: hugo --gc --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
+        run: |
+          hugo --gc --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
+          if grep -R -F '%!' public; then
+            echo "Hugo rendered a formatting error"
+            exit 1
+          fi
       - uses: actions/upload-pages-artifact@v5
         with:
           path: public

--- a/layouts/partials/github-link.html
+++ b/layouts/partials/github-link.html
@@ -1,4 +1,4 @@
-{{- $stars := hugo.Data.github.stars -}}
+{{- $stars := int hugo.Data.github.stars -}}
 {{- $display := printf "%d" $stars -}}
 {{- if ge $stars 1000 -}}
   {{- $display = replaceRE `\.0k$` "k" (printf "%.1fk" (div (float $stars) 1000)) -}}


### PR DESCRIPTION
## Summary

- cast the JSON-backed Hugo star count from `float64` to `int` before formatting
- fail the Pages build if Hugo emits a `%!` formatting diagnostic into generated output

## Verification

- Hugo renders `★7` on both `/` and `/release/v1/`
- generated output contains no `%!` diagnostics
- `actionlint -shellcheck= .github/workflows/pages.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small template and CI guard changes for site display only; no auth, data, or runtime behavior beyond the static Pages build.
> 
> **Overview**
> Fixes broken GitHub star display caused by JSON loading `stargazers_count` as a float while the template formats it with **`%d`**.
> 
> The **`github-link`** partial now casts **`hugo.Data.github.stars`** to **`int`** before **`printf`** and k-formatting. The Pages workflow still runs Hugo the same way, but **fails the build** if any generated file under **`public`** contains Hugo’s **`%!`** formatting diagnostic, so this class of mistake cannot ship silently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a533982069245a81270eaf05ff5e6c883e477587. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->