### PR TITLE
chore: move Renovate config under GitHub metadata

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "local>jdx/renovate-config"
-  ]
+  "extends": ["local>jdx/renovate-config"]
 }


### PR DESCRIPTION
## Summary

- move the shared Renovate configuration to `.github/renovate.json`
- keep extending `local>jdx/renovate-config`

## Validation

- `jq empty .github/renovate.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSON formatting only; no change to dependency update rules or CI behavior.
> 
> **Overview**
> Reformats `.github/renovate.json` so the `extends` entry is on one line instead of a multi-line array. **Behavior is unchanged** — Renovate still extends `local>jdx/renovate-config`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9595d1bec9437cce207b13fb9abd6fc81d44a7cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->