### PR TITLE
fix(site): use logo lockup on spec pages

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -11,9 +11,11 @@
 <body>
 
 <header class="wrap top">
-  <a class="brand" href="/">
-    <svg viewBox="0 0 64 64" aria-hidden="true"><rect x="10" y="6" width="44" height="52" rx="4" fill="none" stroke="currentColor" stroke-width="3"/><path d="M18 20h28M18 30h28M18 40h18" stroke="currentColor" stroke-width="3" stroke-linecap="round"/><circle cx="44" cy="44" r="9" fill="#b8321f"/><path d="M39.5 44l3 3 6-6" stroke="#fff" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
-    packslip
+  <a class="brand" href="/" aria-label="packslip">
+    <picture>
+      <source srcset="/logo-dark.svg" media="(prefers-color-scheme: dark)">
+      <img src="/logo.svg" alt="" width="246" height="64">
+    </picture>
   </a>
   <nav>
     <a href="/">Overview</a>

--- a/static/style.css
+++ b/static/style.css
@@ -94,7 +94,7 @@ pre code { background: none; padding: 0; font-size: inherit; }
   color: var(--ink);
 }
 
-.brand svg { height: 30px; width: auto; display: block; }
+.brand svg, .brand img { height: 30px; width: auto; display: block; }
 
 .top nav { display: flex; gap: 1.4rem; flex-wrap: wrap; }
 .top nav a { color: var(--ink-2); text-decoration: none; font-size: 0.95rem; }


### PR DESCRIPTION
## Summary

- replace the legacy icon-and-text brand on specification pages with the new packslip lockup
- select the matching light or dark logo asset from the user's color-scheme preference
- extend the shared header sizing rule to external logo images

Follow-up to #11 and addresses the issue raised in [this review](https://github.com/jdx/packslip/pull/11#pullrequestreview-5114123315).

## Verification

- `mise x hugo@0.165.0 -- hugo --gc --minify`
- checked rendered spec HTML for both logo asset references and Hugo formatting errors
- `cargo test --all-features`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only header and CSS tweaks on static spec pages; no auth, data, or application logic.
> 
> **Overview**
> Specification pages now use the same **packslip logo lockup** as the rest of the site instead of the old inline icon plus “packslip” text in the header.
> 
> The brand link in `single.html` is a `<picture>` that serves `/logo-dark.svg` when `prefers-color-scheme: dark` and `/logo.svg` otherwise, with `aria-label="packslip"` on the link. **`style.css`** applies the existing 30px header height rule to `.brand img` as well as `.brand svg` so the lockup sizes consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01061a85e8e7a813073985e7ac293c317e145fbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->