### PR TITLE
feat!: drop the supersedes field

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,10 +66,6 @@ inputs:
     description: URL of the release notes; defaults to the release page
     required: false
     default: ""
-  supersedes:
-    description: The version this release replaces
-    required: false
-    default: ""
   sbom:
     description: URL of an SBOM for the release
     required: false
@@ -186,7 +182,6 @@ runs:
         IN_PRERELEASE: ${{ inputs.prerelease }}
         IN_CHANNEL: ${{ inputs.channel }}
         IN_NOTES_URL: ${{ inputs.notes-url }}
-        IN_SUPERSEDES: ${{ inputs.supersedes }}
         IN_SBOM: ${{ inputs.sbom }}
         IN_ATTEST: ${{ inputs.attest }}
         IN_OUT: ${{ inputs.out }}
@@ -226,7 +221,6 @@ runs:
         while IFS= read -r line; do
           [ -n "$line" ] && args+=(--resource "$line")
         done <<< "$IN_RESOURCES"
-        [ -n "$IN_SUPERSEDES" ] && args+=(--supersedes "$IN_SUPERSEDES")
         [ -n "$IN_SBOM" ] && args+=(--sbom "$IN_SBOM")
         mapfile -t files < "${RUNNER_TEMP}/packslip-files"
         if [ "$IN_ATTEST" = true ]; then

--- a/docs/spec/packslip.md
+++ b/docs/spec/packslip.md
@@ -122,8 +122,7 @@ understand the bundle as-is.
       "issuer": "https://token.actions.githubusercontent.com"
     },
     "notes_url": "https://github.com/jdx/mise/releases/tag/v2026.9.1",
-    "sbom": "https://.../sbom.cdx.json",
-    "supersedes": "2026.9.0"
+    "sbom": "https://.../sbom.cdx.json"
   }
 }
 ```
@@ -165,9 +164,8 @@ Rules:
   the build, at whatever SLSA build level its builder establishes.
 - `resources` lists what the release ships besides its executables, each
   entry a `kind` and one source. See Resources.
-- `supersedes` names the release this one replaces, so a consumer can
-  detect a rollback without a version-ordering scheme. `notes_url` points
-  at the release notes.
+- `notes_url` points at the release notes. `sbom` points at a software
+  bill of materials for the release.
 - `identity` says how the document is signed and by whom, so a consumer
   can check what it pinned against what it received. For `sigstore-oidc`,
   `key_id` is the certificate's subject identity (a workflow URI for CI, an
@@ -393,8 +391,8 @@ Eligible means not yanked, not a prerelease unless prereleases were asked
 for, and in the requested channel when one was given. A requested version
 matches as a prefix on dot-separated components under either order, so
 `20` and `3.12` mean what people expect; range constraints are refused
-under `source` rather than guessed. `supersedes` remains a rollback hint
-and takes no part in ordering.
+under `source` rather than guessed. Rollback protection comes from the
+release list's `sequence`, not from anything a single release says.
 
 ## Consumer rules
 
@@ -415,15 +413,14 @@ and takes no part in ordering.
    workflow is the same signer.
 4. Apply any minimum release age to the log's integration time, falling
    back to `published_at` only for an unlogged bundle you chose to accept.
-5. Treat `supersedes` as the ordering hint for rollback detection.
-6. Use the project's release list (GitHub's releases endpoint, or the
+5. Use the project's release list (GitHub's releases endpoint, or the
    signed list) and refuse a project that has neither. Refuse a signed
    list that has expired or whose `sequence` is below the last one
    accepted; never select a yanked entry; skip prereleases unless asked
    for them; order as `version_order` says.
-7. Select one artifact by os, arch, libc, format, and, when needed,
+6. Select one artifact by os, arch, libc, format, and, when needed,
    variant. Refuse to guess between two artifacts that match.
-8. Take each resource from the most verifiable source offered, in the
+7. Take each resource from the most verifiable source offered, in the
    order Resources gives; run an `exec` entry only if you have chosen to
    run vendor code at install time; ignore kinds you do not know.
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -100,8 +100,7 @@
       "issuer": "https://token.actions.githubusercontent.com"
     },
     "notes_url": "https://github.com/jdx/mise/releases/tag/v2026.9.1",
-    "sbom": "https://.../sbom.cdx.json",
-    "supersedes": "2026.9.0"
+    "sbom": "https://.../sbom.cdx.json"
   }
 }</code></pre>
   <p>Rules:</p>
@@ -115,7 +114,7 @@
     <li><code>requires</code> states what the host needs: <code>os_min</code> in the OS's own terms (<code>12</code> for macOS Monterey, <code>10.0.17763</code> for Windows) and <code>glibc_min</code> for a <code>gnu</code> Linux build.</li>
     <li><code>provenance</code> holds URLs of SLSA build provenance statements for that artifact. The packslip proves the manifest; verified provenance proves the build, at whatever SLSA build level its builder establishes.</li>
     <li><code>resources</code> lists what the release ships besides its executables, each entry a <code>kind</code> and one source. See <a href="#resources">Resources</a>.</li>
-    <li><code>supersedes</code> names the release this one replaces, so a consumer can detect a rollback without a version-ordering scheme. <code>notes_url</code> points at the release notes.</li>
+    <li><code>notes_url</code> points at the release notes. <code>sbom</code> points at a software bill of materials for the release.</li>
     <li><code>identity</code> says how the document is signed and by whom, so a consumer can check what it pinned against what it received. For <code>sigstore-oidc</code>, <code>key_id</code> is the certificate's subject identity (a workflow URI for CI, an email for a person) and <code>issuer</code> the OIDC issuer. For <code>sigstore-key</code>, <code>key_id</code> is the key id in uppercase hex.</li>
     <li><code>attested_by</code> is <code>vendor</code> (default) or <code>repackager</code>. See below.</li>
   </ul>
@@ -172,7 +171,6 @@
       <tr><td><code>predicate.evidence[]</code></td><td>array of object</td><td><span class="opt">optional</span></td><td>What a repackager checked: <code>{ kind, detail }</code>.</td></tr>
       <tr><td><code>predicate.notes_url</code></td><td>string</td><td><span class="opt">optional</span></td><td>URL of the release notes.</td></tr>
       <tr><td><code>predicate.sbom</code></td><td>string</td><td><span class="opt">optional</span></td><td>URL of a software bill of materials for the release.</td></tr>
-      <tr><td><code>predicate.supersedes</code></td><td>string</td><td><span class="opt">optional</span></td><td>The version this release replaces.</td></tr>
     </tbody>
   </table>
   </div>
@@ -261,7 +259,7 @@
     <li><code>source</code> (default): the release list's order, newest first, is the ranking. On GitHub that is the releases endpoint's order; on a vendor's own list it is the array order. "Latest" is the first eligible entry.</li>
     <li><code>semver</code>: versions are strict <code>MAJOR.MINOR.PATCH</code> (calver such as <code>2026.9.1</code> qualifies) and sort as semver. "Latest" is the highest eligible version, so a backport such as 20.19.1 published after 22.0.0 never masquerades as the newest release, and range constraints (<code>^1.2</code>) have meaning.</li>
   </ul>
-  <p>Eligible means not yanked, not a prerelease unless prereleases were asked for, and in the requested channel when one was given. A requested version matches as a prefix on dot-separated components under either order, so <code>20</code> and <code>3.12</code> mean what people expect; range constraints are refused under <code>source</code> rather than guessed. <code>supersedes</code> remains a rollback hint and takes no part in ordering.</p>
+  <p>Eligible means not yanked, not a prerelease unless prereleases were asked for, and in the requested channel when one was given. A requested version matches as a prefix on dot-separated components under either order, so <code>20</code> and <code>3.12</code> mean what people expect; range constraints are refused under <code>source</code> rather than guessed. Rollback protection comes from the release list's <code>sequence</code>, not from anything a single release says.</p>
 
   <h2 id="consumer-rules">Consumer rules</h2>
   <ol>
@@ -269,7 +267,6 @@
     <li>Verify the bundle: signature, certificate chain and log entry as sigstore defines them, then the statement's structure, then the subject digest of every artifact or asset you downloaded, and the size of every artifact.</li>
     <li>Enforce no-downgrade: refuse a release whose <code>identity.scheme</code> is weaker than the last accepted one, whose signer changed without a human saying so, whose <code>attested_by</code> went from vendor to repackager, or that dropped per-artifact provenance the last release carried. For a keyless signer, compare the workflow path, not the ref: a new tag of the same workflow is the same signer.</li>
     <li>Apply any minimum release age to the log's integration time, falling back to <code>published_at</code> only for an unlogged bundle you chose to accept.</li>
-    <li>Treat <code>supersedes</code> as the ordering hint for rollback detection.</li>
     <li>Use the project's release list (GitHub's releases endpoint, or the signed list) and refuse a project that has neither. Refuse a signed list that has expired or whose <code>sequence</code> is below the last one accepted; never select a yanked entry; skip prereleases unless asked for them; order as <code>version_order</code> says.</li>
     <li>Select one artifact by os, arch, libc, format, and, when needed, variant. Refuse to guess between two artifacts that match.</li>
     <li>Take each resource from the most verifiable source offered, in the order <a href="#resources">Resources</a> gives; run an <code>exec</code> entry only if you have chosen to run vendor code at install time; ignore kinds you do not know.</li>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -64,8 +64,7 @@
     <span class="k">"identity"</span>: {
       <span class="k">"scheme"</span>: <span class="s">"sigstore-oidc"</span>,
       <span class="k">"key_id"</span>: <span class="s">"https://github.com/jdx/mise/.github/workflows/release.yml@refs/tags/v2026.9.1"</span>,
-      <span class="k">"issuer"</span>: <span class="s">"https://token.actions.githubusercontent.com"</span> },
-    <span class="k">"supersedes"</span>: <span class="s">"2026.9.0"</span>
+      <span class="k">"issuer"</span>: <span class="s">"https://token.actions.githubusercontent.com"</span> }
   }
 }</code></pre>
   </div>
@@ -202,7 +201,6 @@ packslip releases --project mytool.example.com \
         <li><strong>Verify the bundle,</strong> then the statement, then the subject digest and size of every artifact you downloaded.</li>
         <li><strong>Enforce no-downgrade.</strong> Refuse a release whose scheme is weaker than the last accepted one, whose signer changed without a human saying so, or that dropped provenance the last release carried. Compare keyless signers by workflow path, not ref.</li>
         <li><strong>Apply a minimum release age</strong> to the log's integration time, so a hijacked release is noticed before unattended installs pick it up.</li>
-        <li><strong>Treat <code>supersedes</code> as the ordering hint</strong> for rollback detection. Never parse version strings.</li>
         <li><strong>Order by the vendor's word, never by parsing.</strong> Every project has a release list: GitHub's releases endpoint, or a signed list on the vendor's domain. <code>version_order</code> says whether that list's order or semver ranks releases. Refuse a stale signed list, never select a yanked release, skip prereleases unless asked.</li>
         <li><strong>Never guess between two artifacts.</strong> Select by os, arch, libc, format, and variant; if two still match, stop.</li>
       </ol>

--- a/src/create.rs
+++ b/src/create.rs
@@ -30,7 +30,6 @@ pub struct Request<'a> {
     pub url_base: Option<&'a str>,
     pub notes_url: Option<&'a str>,
     pub sbom: Option<&'a str>,
-    pub supersedes: Option<&'a str>,
     /// Who will sign the document.
     pub identity: Identity,
     pub attested_by: Attestor,
@@ -56,7 +55,6 @@ impl<'a> Request<'a> {
             url_base: None,
             notes_url: None,
             sbom: None,
-            supersedes: None,
             identity,
             attested_by: Attestor::Vendor,
             evidence: Vec::new(),
@@ -371,7 +369,6 @@ pub fn create(request: &Request<'_>) -> Result<Created, Error> {
             evidence: request.evidence.clone(),
             notes_url: request.notes_url.map(str::to_string),
             sbom: request.sbom.map(str::to_string),
-            supersedes: request.supersedes.map(str::to_string),
         },
     };
     statement.validate()?;
@@ -709,12 +706,11 @@ mod tests {
             provenance: provenance.iter().map(|s| s.to_string()).collect(),
             ..ArtifactInput::new(path)
         };
-        let request = |artifacts, source, url_base, supersedes| Request {
+        let request = |artifacts, source, url_base| Request {
             published_at: Some("2026-09-01T00:00:00Z"),
             source,
             artifacts,
             url_base,
-            supersedes,
             ..Request::new("tool.example.com", "1.0.0", key_identity(&key))
         };
         let created = create(&request(
@@ -739,7 +735,6 @@ mod tests {
                 tag: Some("v1.0.0".into()),
             }),
             Some("https://github.com/example/tool/releases/download/v1.0.0/"),
-            Some("0.9.0"),
         ))
         .unwrap();
         let arts = &created.statement.predicate.artifacts;
@@ -776,13 +771,11 @@ mod tests {
             vec![input(&a, Some("darwin"), &[], &[])],
             None,
             None,
-            None,
         ))
         .unwrap();
         assert_eq!(overridden.statement.predicate.artifacts[0].libc, None);
         let overridden = create(&request(
             vec![input(&b, Some("linux"), &[], &[])],
-            None,
             None,
             None,
         ))
@@ -799,7 +792,6 @@ mod tests {
             vec![input(&a, None, &[], &[]), input(&fips, None, &[], &[])],
             None,
             None,
-            None,
         ))
         .unwrap_err();
         assert!(matches!(err, Error::Ambiguous { .. }), "{err}");
@@ -812,7 +804,6 @@ mod tests {
                     ..ArtifactInput::new(&fips)
                 },
             ],
-            None,
             None,
             None,
         ))
@@ -890,7 +881,7 @@ mod tests {
                 kind: "pkgbuild-checksums".into(),
                 detail: None,
             }],
-            ..request(vec![input(&b, None, &[], &[])], None, None, None)
+            ..request(vec![input(&b, None, &[], &[])], None, None)
         })
         .unwrap();
         assert!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -330,9 +330,6 @@ struct Create {
     /// SBOM URL
     #[usage(long)]
     sbom: Option<String>,
-    /// The version this release replaces
-    #[usage(long)]
-    supersedes: Option<String>,
     /// Executable inside every archive, as PATH or NAME=PATH (repeatable)
     #[usage(long)]
     bin: Vec<String>,
@@ -550,7 +547,6 @@ impl RunWith<BinInfo> for Create {
             url_base: self.url_base.as_deref(),
             notes_url: self.notes_url.as_deref(),
             sbom: self.sbom.as_deref(),
-            supersedes: self.supersedes.as_deref(),
             attested_by,
             evidence: self.evidence.iter().map(|s| parse_evidence(s)).collect(),
             sha512: !self.no_sha512,

--- a/src/model.rs
+++ b/src/model.rs
@@ -83,9 +83,6 @@ pub struct Predicate {
     pub notes_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sbom: Option<String>,
-    /// The version this release replaces, for ordering.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub supersedes: Option<String>,
 }
 
 /// Who signed the claim.
@@ -959,7 +956,6 @@ mod tests {
                 evidence: vec![],
                 notes_url: None,
                 sbom: None,
-                supersedes: Some("2026.9.0".into()),
             },
         }
     }

--- a/static/schema/release-v1.json
+++ b/static/schema/release-v1.json
@@ -249,13 +249,6 @@
             }
           ]
         },
-        "supersedes": {
-          "description": "The version this release replaces, for ordering.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "version": {
           "type": "string"
         },


### PR DESCRIPTION
## Summary

Removes `predicate.supersedes` from the release statement, the CLI (`--supersedes`), the GitHub Action input, the published JSON schema, the spec, and the site.

## Why

`supersedes` was added so a consumer could detect a rollback by following a chain of releases, back when a packslip was the only signed document a consumer had. Since the release list became required, rollback protection lives entirely there:

- ordering comes from `version_order` (vendor order or semver)
- freshness and anti-rollback come from `sequence` and `expires_at`
- withdrawal comes from `status: "yanked"`

The field had nothing left to do, and the spec had started to contradict itself: the Ordering section said `supersedes` "takes no part in ordering" while consumer rule 5 still told consumers to treat it as the rollback hint. The verifier never read it. On projects with maintenance branches it does not even form a chain (a 20.19.1 backport supersedes 20.19.0, not 22.0.0), so it could not have served as a rollback check across lines anyway.

This is a breaking change to the schema and CLI. Documents that still carry the field remain valid to parse, since unknown predicate fields are not rejected, but `packslip create` no longer emits it.

## Changes

- `src/model.rs`, `src/create.rs`, `src/main.rs`: remove the field, request member, and flag
- `action.yml`: remove the `supersedes` input
- `static/schema/release-v1.json`: regenerated from `packslip schema`
- `docs/spec/packslip.md` and both site layouts: drop the example line, the field rule, the table row, and consumer rule 5; renumber the remaining rules; state that rollback protection comes from the list's `sequence`

## Test plan

- [x] `cargo test`
- [x] `cargo clippy --all-targets`
- [x] `cargo fmt --check`
- [x] `grep -ri supersede` finds nothing outside `.git`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking schema/CLI/action contract for publishers using `--supersedes`; existing bundles with the field should still parse if unknown fields are tolerated, but new manifests will not include it.
> 
> **Overview**
> **Breaking change:** removes `predicate.supersedes` from the release/v1 format and every path that produced or documented it.
> 
> `packslip create` no longer accepts `--supersedes` or writes the field; the GitHub Action drops the `supersedes` input and wiring. The published `release-v1.json` schema and the spec/site examples, field table, and consumer guidance are updated to match.
> 
> **Rollback semantics** are clarified in the docs: consumers should rely on the signed release list’s `sequence` (and related list rules), not a per-release chain. The old consumer rule that treated `supersedes` as a rollback hint is removed and the remaining rules are renumbered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01b31c1f8be8f07e1a2a5c022d9896fabe64a90c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->