### PR TITLE
fix: refuse two different assets that share a file name

### DIFF
--- a/src/create.rs
+++ b/src/create.rs
@@ -125,6 +125,10 @@ pub enum Error {
     #[error("{path}: not a packslip bundle: {why}")]
     NotAPackslip { path: String, why: String },
     #[error(
+        "asset {path} is named {name:?}, but a different file with that name was already given"
+    )]
+    AssetCollision { name: String, path: String },
+    #[error(
         "artifacts {a:?} and {b:?} both describe {platform}; give one a variant so consumers can tell them apart"
     )]
     Ambiguous {
@@ -312,15 +316,28 @@ pub fn create(request: &Request<'_>) -> Result<Created, Error> {
         artifacts.push(artifact);
     }
     let mut asset_urls = std::collections::BTreeMap::new();
+    let mut asset_digests: std::collections::BTreeMap<String, String> =
+        std::collections::BTreeMap::new();
     for asset in &request.assets {
         let name = file_name(asset.path);
-        if asset_urls.contains_key(&name) {
-            continue;
-        }
         let digests = crate::digest_file_all(asset.path).map_err(|source| Error::Io {
             path: asset.path.display().to_string(),
             source,
         })?;
+        // The same file given twice is one asset; two different files that
+        // share a name cannot both be the subject that name would carry.
+        match asset_digests.get(&name) {
+            Some(seen) if *seen == digests.sha256 => continue,
+            Some(_) => {
+                return Err(Error::AssetCollision {
+                    name,
+                    path: asset.path.display().to_string(),
+                });
+            }
+            None => {
+                asset_digests.insert(name.clone(), digests.sha256.clone());
+            }
+        }
         let url = asset.url.clone().or_else(|| {
             request
                 .url_base
@@ -655,6 +672,36 @@ mod tests {
         assert_eq!(swept.statement.predicate.artifacts.len(), 1);
         assert_eq!(swept.statement.subject.len(), 2);
         assert_eq!(swept.statement.subject[1].name, "tool-skill.tar.gz");
+
+        // Two different files sharing a name are refused, not collapsed.
+        let elsewhere = dir.path().join("elsewhere");
+        std::fs::create_dir_all(&elsewhere).unwrap();
+        let other_skill = elsewhere.join("tool-skill.tar.gz");
+        std::fs::write(&other_skill, b"different bytes").unwrap();
+        let err = create(&Request {
+            artifacts: vec![ArtifactInput {
+                bin: vec![Bin::new("tool")],
+                ..ArtifactInput::new(&a)
+            }],
+            assets: vec![
+                AssetInput {
+                    path: &skill,
+                    url: None,
+                },
+                AssetInput {
+                    path: &other_skill,
+                    url: None,
+                },
+            ],
+            resources: vec![Resource {
+                name: Some("tool".into()),
+                asset: Some("tool-skill.tar.gz".into()),
+                ..Resource::new("skill")
+            }],
+            ..Request::new("tool.example.com", "1.0.0", key_identity(&key))
+        })
+        .unwrap_err();
+        assert!(matches!(err, Error::AssetCollision { .. }), "{err}");
 
         // The asset digest is checked like an artifact's, and a resource
         // whose asset was not given is refused.


### PR DESCRIPTION
Follow-up to the last Cursor Bugbot finding on #5, which landed after the merge: a second `--resource ...=asset:PATH` whose file name matched an earlier asset was skipped without comparing the files, so two different files could collapse into one subject and a later resource could inherit the wrong digest.

Now the same file given twice is still one asset, and a different file under a name already taken fails `create` with a clear error. Covered by a create-level test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Validation-only change at statement build time; prevents incorrect subject digests without altering signing or verification paths.
> 
> **Overview**
> **Packslip `create` no longer silently drops a second asset when its basename matches an earlier one.** Asset inputs are deduplicated by file name only when the SHA256 digest matches (same path/content given twice still yields one subject entry). If two different files share a name, `create` fails with **`AssetCollision`** instead of keeping the first digest—so resources keyed by that asset name cannot point at the wrong bytes.
> 
> A create-level test covers two distinct `tool-skill.tar.gz` paths and expects `Error::AssetCollision`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43b888ff5f4a5d2170d5725e3b0d886f4989c82f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->