### PR TITLE
feat!: require semver and derive prerelease and channel from the version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,6 +1226,7 @@ dependencies = [
  "getrandom 0.3.4",
  "jiff",
  "schemars",
+ "semver",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ eyre = "0.6"
 getrandom = "0.3"
 jiff = "0.2"
 schemars = "1"
+semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/action.yml
+++ b/action.yml
@@ -54,14 +54,6 @@ inputs:
       matched is treated as the asset, not an artifact).
     required: false
     default: ""
-  prerelease:
-    description: Mark the release as not for general use; defaults to the GitHub release's flag
-    required: false
-    default: ""
-  channel:
-    description: The release channel (stable, beta, nightly)
-    required: false
-    default: ""
   notes-url:
     description: URL of the release notes; defaults to the release page
     required: false
@@ -179,13 +171,10 @@ runs:
         IN_BIN: ${{ inputs.bin }}
         IN_VARIANTS: ${{ inputs.variants }}
         IN_RESOURCES: ${{ inputs.resources }}
-        IN_PRERELEASE: ${{ inputs.prerelease }}
-        IN_CHANNEL: ${{ inputs.channel }}
         IN_NOTES_URL: ${{ inputs.notes-url }}
         IN_SBOM: ${{ inputs.sbom }}
         IN_ATTEST: ${{ inputs.attest }}
         IN_OUT: ${{ inputs.out }}
-        EVENT_PRERELEASE: ${{ github.event.release.prerelease }}
         REPO: ${{ github.repository }}
         REF_NAME: ${{ github.ref_name }}
         REF_TYPE: ${{ github.ref_type }}
@@ -203,7 +192,6 @@ runs:
         project="${IN_PROJECT:-github.com/${REPO}}"
         url_base="${IN_URL_BASE:-${SERVER}/${REPO}/releases/download/${tag}}"
         notes_url="${IN_NOTES_URL:-${SERVER}/${REPO}/releases/tag/${tag}}"
-        prerelease="${IN_PRERELEASE:-${EVENT_PRERELEASE:-false}}"
         args=(
           create
           --project "$project"
@@ -215,8 +203,6 @@ runs:
           --tag "$tag"
           --commit "$SHA"
         )
-        [ "$prerelease" = true ] && args+=(--prerelease)
-        [ -n "$IN_CHANNEL" ] && args+=(--channel "$IN_CHANNEL")
         for b in $IN_BIN; do args+=(--bin "$b"); done
         while IFS= read -r line; do
           [ -n "$line" ] && args+=(--resource "$line")

--- a/content/cli/create.md
+++ b/content/cli/create.md
@@ -25,9 +25,6 @@ Digests every artifact, infers os/arch/libc/format from file names (override wit
 - **`--commit <COMMIT>`** — Source commit
 - **`--tag <TAG>`** — Source tag
 - **`--published-at <PUBLISHED_AT>`** — RFC 3339 publish time; defaults to now
-- **`--prerelease`** — Mark the release as not for general use
-- **`--channel <CHANNEL>`** — The release channel: stable, beta, nightly
-- **`--version-order <VERSION_ORDER>`** — How consumers order this project's versions: source (the release list's order, the default) or semver (strict MAJOR.MINOR.PATCH, calver included)
 - **`--notes-url <NOTES_URL>`** — URL of the release notes
 - **`--sbom <SBOM>`** — SBOM URL
 - **`--bin <BIN>`** — Executable inside every archive, as PATH or NAME=PATH (repeatable)

--- a/content/cli/releases.md
+++ b/content/cli/releases.md
@@ -10,7 +10,6 @@ For a project on its own domain: lists released packslips with their digests so 
 ## Flags
 - **`--project <PROJECT>`** — The project's name, which every listed packslip must carry
 - **`--sequence <SEQUENCE>`** — Increases with every list published
-- **`--version-order <VERSION_ORDER>`** — How consumers order the listed versions: source (this list's order, the default) or semver
 - **`--valid-for <VALID_FOR>`** — How long the list stays current: 30d, 12h, 2w
 
   **Default:** `30d`

--- a/docs/spec/packslip.md
+++ b/docs/spec/packslip.md
@@ -93,7 +93,6 @@ and `gh attestation` understand the bundle as-is.
     "project": "github.com/jdx/mise",
     "version": "2026.9.1",
     "published_at": "2026-09-01T12:00:00Z",
-    "channel": "stable",
     "source": { "repo": "https://github.com/jdx/mise", "commit": "...", "tag": "v2026.9.1" },
     "artifacts": [
       {
@@ -133,12 +132,9 @@ Rules:
   artifact or a resource's `asset`, and neither list contains a duplicate.
   At least one artifact is required. `sha256` is required and is 64
   lowercase hex characters; `sha512` is optional and 128.
-- `project` is a name as defined above. `version` is the vendor's version
-  string, compared as opaque text. `published_at` is RFC 3339 UTC.
-- `prerelease` (default false) marks a release not meant for general use;
-  consumers skip it unless asked for prereleases. `channel` is the vendor's
-  own word for the release track (`stable`, `beta`, `nightly`).
-  `version_order` is `source` (default) or `semver`; see Ordering versions.
+- `project` is a name as defined above. `version` is semver 2.0.0; its
+  prerelease part, if any, says whether the release is a prerelease and
+  which channel it is on. See Versions. `published_at` is RFC 3339 UTC.
 - `os`, `arch`, and `libc` use the values `linux`, `darwin`, `windows`,
   `freebsd`; `x86_64`, `aarch64`, `armv7`, `riscv64`, `i686`; `gnu`,
   `musl`. `format` is the archive or installer type: `tar.xz`, `tar.gz`,
@@ -296,12 +292,15 @@ pre-authentication encoding of the payload.
 Publish the bundle next to the artifacts: as a release asset, or under the
 version directory of a download site.
 
-Every project has a release list, and it is what consumers order by:
+Every project has a release list, and it is where consumers find what
+was released and what was withdrawn:
 
 - For `github.com/<owner>/<repo>[/<tool>]` the list is the repository's
-  releases endpoint. Its order is the vendor's order. A release counts
-  when it is not a draft and carries a packslip whose `project` matches;
-  to yank one, remove its packslip asset or the release.
+  releases endpoint. A release counts when it is not a draft and carries
+  a packslip whose `project` matches. The endpoint's order and its
+  prerelease flag are not consulted; the version says both. To yank a
+  release, delete it, or delete its packslip asset where the repository
+  still permits that.
 - Any other project publishes a signed list at
 
 ```
@@ -330,7 +329,6 @@ guessing at URLs. It is a bundle of the same shape as a packslip, with the
     "expires_at": "2026-10-01T12:00:00Z",
     "sequence": 42,
     "identity": { "scheme": "sigstore-key", "key_id": "5A0A0B8B9C6D7E1F" },
-    "version_order": "semver",
     "releases": [
       { "version": "2026.9.1", "published_at": "2026-09-01T12:00:00Z",
         "packslip": "https://dl.example.com/2026.9.1/packslip.sigstore.json",
@@ -349,11 +347,11 @@ the list pins the exact documents it points at. `expires_at` and
 list that has expired, or whose sequence is lower than one it has already
 accepted, so a mirror cannot freeze or roll back the vendor's view.
 
-Each entry may carry `prerelease` and `channel` (copied from the
-packslip), `status: "yanked"` with a `status_reason` when the vendor
-withdrew the release, and `security: true` when it fixes a vulnerability.
-A consumer never selects a yanked release, warns when it holds one, and
-may shorten its minimum release age for a security release.
+Each entry may carry `status: "yanked"` with a `status_reason` when the
+vendor withdrew the release, and `security: true` when it fixes a
+vulnerability. A consumer never selects a yanked release, warns when it
+holds one, and may shorten its minimum release age for a security release.
+Nothing else about a release lives on the list: its version says the rest.
 
 `packslip releases` produces the list from local copies of the released
 bundles; the JSON schema is at
@@ -362,29 +360,50 @@ bundles; the JSON schema is at
 The list separates the name from where the bytes live: the identity is
 anchored to the domain, and the artifacts can be anywhere.
 
-## Ordering versions
+## Versions
 
-`version` is the vendor's string, and a consumer never infers an ordering
-scheme from it. Projects switch schemes over their history, two-component
-versions parse and sort wrong, and date versions look like semver. Instead
-the vendor declares how its versions order with `version_order`, on each
-release and on the list, using the two values mise's registry uses:
+`version` is a semver 2.0.0 version: `MAJOR.MINOR.PATCH`, an optional
+prerelease part after `-`, optional build metadata after `+`. Calver such
+as `2026.9.1` qualifies. `packslip create` refuses anything else, and so
+does a consumer. The tag can be spelled however the vendor likes
+(`v2026.9.1`, `oxlint_v1.0.0`); `source.tag` carries it.
 
-- `source` (default): the release list's order, newest first, is the
-  ranking. On GitHub that is the releases endpoint's order; on a vendor's
-  own list it is the array order. "Latest" is the first eligible entry.
-- `semver`: versions are strict `MAJOR.MINOR.PATCH` (calver such as
-  `2026.9.1` qualifies) and sort as semver. "Latest" is the highest eligible
-  version, so a backport such as 20.19.1 published after 22.0.0 never
-  masquerades as the newest release, and range constraints (`^1.2`) have
-  meaning.
+One required scheme is what lets everything about a release follow from
+its signed version string, with no flag anywhere that could disagree with
+it:
+
+- Order is semver precedence. "Latest" is the highest eligible version, so
+  a backport such as 20.19.1 published after 22.0.0 never masquerades as
+  the newest release, and range constraints (`^1.2`) have meaning. Build
+  metadata takes no part, as semver says. The order of the release list,
+  GitHub's or the vendor's, is not consulted.
+- A prerelease is a version with a prerelease part: `1.2.0-rc.1` is one,
+  `1.2.0` is not. Consumers skip prereleases unless asked for them.
+  Promoting a release candidate means cutting the final version, not
+  editing a flag.
+- A channel is the first identifier of the prerelease part, when that is
+  not a number: `1.3.0-nightly.20260904` is on `nightly`, `1.2.0-beta.2` on
+  `beta`, `1.2.0-rc.1` on `rc`. A release with no prerelease part is on no
+  channel, and so is `1.2.0-1`. A consumer asked for a channel selects
+  only releases on it, ranked by precedence. The names are the vendor's;
+  packslip defines none.
 
 Eligible means not yanked, not a prerelease unless prereleases were asked
-for, and in the requested channel when one was given. A requested version
-matches as a prefix on dot-separated components under either order, so
-`20` and `3.12` mean what people expect; range constraints are refused
-under `source` rather than guessed. Rollback protection comes from the
-release list's `sequence`, not from anything a single release says.
+for, and on the requested channel when one was given. A requested version
+matches as a prefix on dot-separated components, so `20` and `3.12` mean
+what people expect and `1.2.0-beta` means the betas of 1.2.0. Rollback
+protection comes from the release list's `sequence`, not from anything a
+single release says.
+
+A packslip carries none of this as a field, on purpose. It is signed once,
+and on a GitHub repository with immutable releases it can never be
+replaced, while GitHub's own prerelease flag stays editable after
+publishing. A flag in the document would end up either frozen or
+contradicted. So the packslip says what shipped, the version says how to
+treat it, and the one thing that stays mutable, withdrawing a release, is
+the release list's job. An earlier draft let a vendor declare list order
+instead of semver; it went, because the prerelease and channel fields it
+then needed had no honest home.
 
 ## Consumer rules
 
@@ -409,7 +428,7 @@ release list's `sequence`, not from anything a single release says.
    signed list) and refuse a project that has neither. Refuse a signed
    list that has expired or whose `sequence` is below the last one
    accepted; never select a yanked entry; skip prereleases unless asked
-   for them; order as `version_order` says.
+   for them; rank by semver precedence.
 6. Select one artifact by os, arch, libc, format, and, when needed,
    variant. Refuse to guess between two artifacts that match.
 7. Take each resource from the most verifiable source offered, in the
@@ -456,8 +475,8 @@ Action.
   - Executables: `--bin NAME=PATH` when the name on PATH differs from the
     file.
   - URLs: `--url FILENAME=URL` sets one artifact's or asset's URL.
-  - Metadata: `--prerelease`, `--channel`, `--notes-url`, `--no-sha512`,
-    and `--attested-by repackager` with `--evidence KIND[=DETAIL]`.
+  - Metadata: `--notes-url`, `--no-sha512`, and `--attested-by repackager`
+    with `--evidence KIND[=DETAIL]`.
   - Resources: `--resource KIND[/QUALIFIER]=SOURCE:VALUE`, as in
     `completion/zsh=archive:share/zsh/site-functions/_tool`,
     `completion/bash,zsh,fish=exec:tool completion {shell}`,

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -27,7 +27,7 @@
     <li><a href="#repackager">Repackager attestation</a></li>
     <li><a href="#signing">Signing</a></li>
     <li><a href="#discovery">Discovery</a></li>
-    <li><a href="#ordering">Ordering versions</a></li>
+    <li><a href="#versions">Versions</a></li>
     <li><a href="#consumer-rules">Consumer rules</a></li>
     <li><a href="#proves">What it proves</a></li>
     <li><a href="#tooling">Tooling</a></li>
@@ -74,7 +74,6 @@
     "project": "github.com/jdx/mise",
     "version": "2026.9.1",
     "published_at": "2026-09-01T12:00:00Z",
-    "channel": "stable",
     "source": { "repo": "https://github.com/jdx/mise", "commit": "...", "tag": "v2026.9.1" },
     "artifacts": [
       {
@@ -106,8 +105,7 @@
   <p>Rules:</p>
   <ul>
     <li><code>subject</code> lists every artifact by file name with its digests, plus any separate file a resource comes from. <code>artifacts</code> carries the same names with platform, size, download URL, format, executables, requirements, and provenance links. Every artifact is a subject, every subject is an artifact or a resource's <code>asset</code>, and neither list contains a duplicate. At least one artifact is required. <code>sha256</code> is required and is 64 lowercase hex characters; <code>sha512</code> is optional and 128.</li>
-    <li><code>project</code> is a name as defined above. <code>version</code> is the vendor's version string, compared as opaque text. <code>published_at</code> is RFC 3339 UTC.</li>
-    <li><code>prerelease</code> (default false) marks a release not meant for general use; consumers skip it unless asked for prereleases. <code>channel</code> is the vendor's own word for the release track (<code>stable</code>, <code>beta</code>, <code>nightly</code>). <code>version_order</code> is <code>source</code> (default) or <code>semver</code>; see <a href="#ordering">Ordering versions</a>.</li>
+    <li><code>project</code> is a name as defined above. <code>version</code> is semver 2.0.0; its prerelease part, if any, says whether the release is a prerelease and which channel it is on. See <a href="#versions">Versions</a>. <code>published_at</code> is RFC 3339 UTC.</li>
     <li><code>os</code>, <code>arch</code>, and <code>libc</code> use the values <code>linux</code>, <code>darwin</code>, <code>windows</code>, <code>freebsd</code>; <code>x86_64</code>, <code>aarch64</code>, <code>armv7</code>, <code>riscv64</code>, <code>i686</code>; <code>gnu</code>, <code>musl</code>. <code>format</code> is the archive or installer type: <code>tar.xz</code>, <code>tar.gz</code>, <code>tar.zst</code>, <code>tar.bz2</code>, <code>tgz</code>, <code>zip</code>, <code>7z</code>, <code>deb</code>, <code>rpm</code>, <code>dmg</code>, <code>pkg</code>, <code>msi</code>, <code>msix</code>, <code>exe</code>, <code>appimage</code>, or <code>raw</code> for a bare executable.</li>
     <li><code>variant</code> tells apart artifacts that share os, arch, libc, and format: <code>fips</code>, <code>baseline</code>, <code>debug</code>, <code>installer</code>, <code>source</code>. A vendor must not publish two artifacts that agree on all five; <code>packslip create</code> refuses to. Consumers that find such a pair refuse to choose.</li>
     <li><code>bin</code> lists the executables inside the artifact. Each entry is a path relative to the archive root, or the artifact's own name when it is a bare executable. When the name to put on PATH differs from the file name, the entry is <code>{ "path": "bin/oxlint-x86_64", "name": "oxlint" }</code>. Windows entries carry their <code>.exe</code>.</li>
@@ -131,11 +129,8 @@
       <tr><td><code>subject[].digest.sha512</code></td><td>string</td><td><span class="opt">optional</span></td><td>SHA-512 of the file, lowercase hex.</td></tr>
       <tr><td><code>predicateType</code></td><td>string</td><td><span class="req">required</span></td><td>Always <code>https://packslip.dev/release/v1</code>.</td></tr>
       <tr><td><code>predicate.project</code></td><td>string</td><td><span class="req">required</span></td><td>Host path naming the project, such as <code>github.com/jdx/mise</code> or <code>github.com/oxc-project/oxc/oxlint</code>.</td></tr>
-      <tr><td><code>predicate.version</code></td><td>string</td><td><span class="req">required</span></td><td>The vendor's version string. Opaque; never parsed for ordering.</td></tr>
+      <tr><td><code>predicate.version</code></td><td>string</td><td><span class="req">required</span></td><td>Semver 2.0.0. Its prerelease part marks a prerelease and names the channel.</td></tr>
       <tr><td><code>predicate.published_at</code></td><td>string</td><td><span class="req">required</span></td><td>RFC 3339 UTC publish time.</td></tr>
-      <tr><td><code>predicate.prerelease</code></td><td>boolean</td><td><span class="opt">optional</span></td><td>Not for general use. Default false.</td></tr>
-      <tr><td><code>predicate.channel</code></td><td>string</td><td><span class="opt">optional</span></td><td>Release track: <code>stable</code>, <code>beta</code>, <code>nightly</code>.</td></tr>
-      <tr><td><code>predicate.version_order</code></td><td>string</td><td><span class="opt">optional</span></td><td><code>source</code> (default: the release list's order) or <code>semver</code>.</td></tr>
       <tr><td><code>predicate.source</code></td><td>object</td><td><span class="opt">optional</span></td><td>Where the release was built from.</td></tr>
       <tr><td><code>predicate.source.repo</code></td><td>string</td><td><span class="req">required</span></td><td>Source repository URL.</td></tr>
       <tr><td><code>predicate.source.commit</code></td><td>string</td><td><span class="opt">optional</span></td><td>Commit the release was built from.</td></tr>
@@ -217,9 +212,9 @@
 
   <h2 id="discovery">Discovery</h2>
   <p>Publish the bundle next to the artifacts: as a release asset, or under the version directory of a download site.</p>
-  <p>Every project has a release list, and it is what consumers order by:</p>
+  <p>Every project has a release list, and it is where consumers find what was released and what was withdrawn:</p>
   <ul>
-    <li>For <code>github.com/&lt;owner&gt;/&lt;repo&gt;[/&lt;tool&gt;]</code> the list is the repository's releases endpoint. Its order is the vendor's order. A release counts when it is not a draft and carries a packslip whose <code>project</code> matches; to yank one, remove its packslip asset or the release.</li>
+    <li>For <code>github.com/&lt;owner&gt;/&lt;repo&gt;[/&lt;tool&gt;]</code> the list is the repository's releases endpoint. A release counts when it is not a draft and carries a packslip whose <code>project</code> matches. The endpoint's order and its prerelease flag are not consulted; the version says both. To yank a release, delete it, or delete its packslip asset where the repository still permits that.</li>
     <li>Any other project publishes a signed list at <code>https://&lt;host&gt;/.well-known/packslip/&lt;path&gt;.json</code>, where <code>&lt;path&gt;</code> is the project name after the host, or <code>packslip.json</code> directly under <code>.well-known</code> when the name is a bare host.</li>
   </ul>
   <p>The list is required: a consumer that finds none refuses the project rather than guessing at URLs. It is a bundle of the same shape as a packslip, with the <code>releases/v1</code> predicate:</p>
@@ -238,7 +233,6 @@
     "expires_at": "2026-10-01T12:00:00Z",
     "sequence": 42,
     "identity": { "scheme": "sigstore-key", "key_id": "5A0A0B8B9C6D7E1F" },
-    "version_order": "semver",
     "releases": [
       { "version": "2026.9.1", "published_at": "2026-09-01T12:00:00Z",
         "packslip": "https://dl.example.com/2026.9.1/packslip.sigstore.json",
@@ -250,16 +244,19 @@
   }
 }</code></pre>
   <p>Each subject is a listed packslip's URL with the digest of that file, so the list pins the exact documents it points at. <code>expires_at</code> and <code>sequence</code> are borrowed from TUF's timestamp role: a consumer refuses a list that has expired, or whose sequence is lower than one it has already accepted, so a mirror cannot freeze or roll back the vendor's view.</p>
-  <p>Each entry may carry <code>prerelease</code> and <code>channel</code> (copied from the packslip), <code>status: "yanked"</code> with a <code>status_reason</code> when the vendor withdrew the release, and <code>security: true</code> when it fixes a vulnerability. A consumer never selects a yanked release, warns when it holds one, and may shorten its minimum release age for a security release.</p>
+  <p>Each entry may carry <code>status: "yanked"</code> with a <code>status_reason</code> when the vendor withdrew the release, and <code>security: true</code> when it fixes a vulnerability. A consumer never selects a yanked release, warns when it holds one, and may shorten its minimum release age for a security release. Nothing else about a release lives on the list: its version says the rest.</p>
   <p><code>packslip releases</code> produces the list from local copies of the released bundles. The list separates the name from where the bytes live: the identity is anchored to the domain, and the artifacts can be anywhere.</p>
 
-  <h2 id="ordering">Ordering versions</h2>
-  <p><code>version</code> is the vendor's string, and a consumer never infers an ordering scheme from it. Projects switch schemes over their history, two-component versions parse and sort wrong, and date versions look like semver. Instead the vendor declares how its versions order with <code>version_order</code>, on each release and on the list, using the two values mise's registry uses:</p>
+  <h2 id="versions">Versions</h2>
+  <p><code>version</code> is a semver 2.0.0 version: <code>MAJOR.MINOR.PATCH</code>, an optional prerelease part after <code>-</code>, optional build metadata after <code>+</code>. Calver such as <code>2026.9.1</code> qualifies. <code>packslip create</code> refuses anything else, and so does a consumer. The tag can be spelled however the vendor likes (<code>v2026.9.1</code>, <code>oxlint_v1.0.0</code>); <code>source.tag</code> carries it.</p>
+  <p>One required scheme is what lets everything about a release follow from its signed version string, with no flag anywhere that could disagree with it:</p>
   <ul>
-    <li><code>source</code> (default): the release list's order, newest first, is the ranking. On GitHub that is the releases endpoint's order; on a vendor's own list it is the array order. "Latest" is the first eligible entry.</li>
-    <li><code>semver</code>: versions are strict <code>MAJOR.MINOR.PATCH</code> (calver such as <code>2026.9.1</code> qualifies) and sort as semver. "Latest" is the highest eligible version, so a backport such as 20.19.1 published after 22.0.0 never masquerades as the newest release, and range constraints (<code>^1.2</code>) have meaning.</li>
+    <li>Order is semver precedence. "Latest" is the highest eligible version, so a backport such as 20.19.1 published after 22.0.0 never masquerades as the newest release, and range constraints (<code>^1.2</code>) have meaning. Build metadata takes no part, as semver says. The order of the release list, GitHub's or the vendor's, is not consulted.</li>
+    <li>A prerelease is a version with a prerelease part: <code>1.2.0-rc.1</code> is one, <code>1.2.0</code> is not. Consumers skip prereleases unless asked for them. Promoting a release candidate means cutting the final version, not editing a flag.</li>
+    <li>A channel is the first identifier of the prerelease part, when that is not a number: <code>1.3.0-nightly.20260904</code> is on <code>nightly</code>, <code>1.2.0-beta.2</code> on <code>beta</code>, <code>1.2.0-rc.1</code> on <code>rc</code>. A release with no prerelease part is on no channel, and so is <code>1.2.0-1</code>. A consumer asked for a channel selects only releases on it, ranked by precedence. The names are the vendor's; packslip defines none.</li>
   </ul>
-  <p>Eligible means not yanked, not a prerelease unless prereleases were asked for, and in the requested channel when one was given. A requested version matches as a prefix on dot-separated components under either order, so <code>20</code> and <code>3.12</code> mean what people expect; range constraints are refused under <code>source</code> rather than guessed. Rollback protection comes from the release list's <code>sequence</code>, not from anything a single release says.</p>
+  <p>Eligible means not yanked, not a prerelease unless prereleases were asked for, and on the requested channel when one was given. A requested version matches as a prefix on dot-separated components, so <code>20</code> and <code>3.12</code> mean what people expect and <code>1.2.0-beta</code> means the betas of 1.2.0. Rollback protection comes from the release list's <code>sequence</code>, not from anything a single release says.</p>
+  <p>A packslip carries none of this as a field, on purpose. It is signed once, and on a GitHub repository with immutable releases it can never be replaced, while GitHub's own prerelease flag stays editable after publishing. A flag in the document would end up either frozen or contradicted. So the packslip says what shipped, the version says how to treat it, and the one thing that stays mutable, withdrawing a release, is the release list's job. An earlier draft let a vendor declare list order instead of semver; it went, because the prerelease and channel fields it then needed had no honest home.</p>
 
   <h2 id="consumer-rules">Consumer rules</h2>
   <ol>
@@ -267,7 +264,7 @@
     <li>Verify the bundle: signature, certificate chain and log entry as sigstore defines them, then the statement's structure, then the subject digest of every artifact or asset you downloaded, and the size of every artifact.</li>
     <li>Enforce no-downgrade: refuse a release whose <code>identity.scheme</code> is weaker than the last accepted one, whose signer changed without a human saying so, whose <code>attested_by</code> went from vendor to repackager, or that dropped per-artifact provenance the last release carried. For a keyless signer, compare the workflow path, not the ref: a new tag of the same workflow is the same signer.</li>
     <li>Apply any minimum release age to the log's integration time, falling back to <code>published_at</code> only for an unlogged bundle you chose to accept.</li>
-    <li>Use the project's release list (GitHub's releases endpoint, or the signed list) and refuse a project that has neither. Refuse a signed list that has expired or whose <code>sequence</code> is below the last one accepted; never select a yanked entry; skip prereleases unless asked for them; order as <code>version_order</code> says.</li>
+    <li>Use the project's release list (GitHub's releases endpoint, or the signed list) and refuse a project that has neither. Refuse a signed list that has expired or whose <code>sequence</code> is below the last one accepted; never select a yanked entry; skip prereleases unless asked for them; rank by semver precedence.</li>
     <li>Select one artifact by os, arch, libc, format, and, when needed, variant. Refuse to guess between two artifacts that match.</li>
     <li>Take each resource from the most verifiable source offered, in the order <a href="#resources">Resources</a> gives; run an <code>exec</code> entry only if you have chosen to run vendor code at install time; ignore kinds you do not know.</li>
   </ol>
@@ -286,7 +283,7 @@
         <li>Platforms: <code>path:os/arch[/libc]</code> overrides what the file name implies; <code>path@variant</code> marks a second build of one platform.</li>
         <li>Executables: <code>--bin NAME=PATH</code> when the name on PATH differs from the file.</li>
         <li>URLs: <code>--url FILENAME=URL</code> sets one artifact's or asset's URL.</li>
-        <li>Metadata: <code>--prerelease</code>, <code>--channel</code>, <code>--notes-url</code>, <code>--no-sha512</code>, and <code>--attested-by repackager</code> with <code>--evidence KIND[=DETAIL]</code>.</li>
+        <li>Metadata: <code>--notes-url</code>, <code>--no-sha512</code>, and <code>--attested-by repackager</code> with <code>--evidence KIND[=DETAIL]</code>.</li>
         <li>Resources: <code>--resource KIND[/QUALIFIER]=SOURCE:VALUE</code>, as in <code>completion/zsh=archive:share/zsh/site-functions/_tool</code>, <code>completion/bash,zsh,fish=exec:tool completion {shell}</code>, <code>man=archive:man/man1/tool.1</code>, <code>cli-spec/usage=exec:tool usage</code>, <code>skill/NAME=repo:skills/tool</code>, <code>skill/NAME=asset:dist/tool-skill.tar.gz</code>, <code>desktop=archive:...</code>, <code>icon=archive:...</code>, or <code>app=archive:Tool.app</code>. A <code>cli-spec</code> describes the sole <code>--bin</code> unless named as <code>cli-spec/usage/NAME</code>. An <code>asset</code> is a local file digested into the subject; a file given as both an artifact and an asset is the asset.</li>
         <li>Signing: <code>--key release.key</code> signs with a key; <code>--no-log</code> skips Rekor.</li>
       </ul>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -201,7 +201,7 @@ packslip releases --project mytool.example.com \
         <li><strong>Verify the bundle,</strong> then the statement, then the digest and size of every artifact you downloaded.</li>
         <li><strong>Never downgrade.</strong> Refuse a release signed with a weaker scheme than the last one you accepted, signed by someone new without a human approving it, or missing provenance the last release had. A keyless signer is its workflow path, so a new tag of the same workflow is the same signer.</li>
         <li><strong>Wait before installing.</strong> Apply a minimum release age to the time the transparency log recorded, so a hijacked release is noticed before unattended installs pick it up.</li>
-        <li><strong>Let the vendor order releases.</strong> Every project has a release list: GitHub's releases endpoint, or a signed list on the vendor's domain. Take the order from it, sort as semver only when the vendor says to, and never guess the scheme from the version string. Refuse a stale signed list, never pick a yanked release, and skip prereleases unless asked.</li>
+        <li><strong>Order by semver.</strong> Every version is semver: precedence ranks releases, a prerelease part marks a prerelease, and its first identifier names the channel. Every project has a release list: GitHub's releases endpoint, or a signed list on the vendor's domain. It says what was released and what was withdrawn, nothing more. Refuse a stale signed list, never pick a yanked release, and skip prereleases unless asked.</li>
         <li><strong>Never guess between two artifacts.</strong> Select by os, arch, libc, format, and variant. If two still match, stop.</li>
       </ol>
 <pre><code>packslip verify packslip.sigstore.json \

--- a/packslip.usage.kdl
+++ b/packslip.usage.kdl
@@ -52,13 +52,6 @@ Digests every artifact, infers os/arch/libc/format from file names (override wit
     flag --published-at help="RFC 3339 publish time; defaults to now" {
         arg <PUBLISHED_AT>
     }
-    flag --prerelease help="Mark the release as not for general use"
-    flag --channel help="The release channel: stable, beta, nightly" {
-        arg <CHANNEL>
-    }
-    flag --version-order help="How consumers order this project's versions: source (the release list's order, the default) or semver (strict MAJOR.MINOR.PATCH, calver included)" {
-        arg <VERSION_ORDER>
-    }
     flag --notes-url help="URL of the release notes" {
         arg <NOTES_URL>
     }
@@ -107,9 +100,6 @@ For a project on its own domain: lists released packslips with their digests so 
     }
     flag --sequence help="Increases with every list published" required=#true {
         arg <SEQUENCE>
-    }
-    flag --version-order help="How consumers order the listed versions: source (this list's order, the default) or semver" {
-        arg <VERSION_ORDER>
     }
     flag --valid-for help="How long the list stays current: 30d, 12h, 2w" default="30d" {
         arg <VALID_FOR>

--- a/src/create.rs
+++ b/src/create.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use crate::model::{
     Artifact, Attestor, Bin, Digest, Envelope, Evidence, Identity, PREDICATE_TYPE, Predicate,
     RELEASES_PREDICATE_TYPE, ReleaseList, ReleaseListStatement, ReleaseRef, Requires, Resource,
-    STATEMENT_TYPE, Source, Statement, Subject, VersionOrder,
+    STATEMENT_TYPE, Source, Statement, Subject,
 };
 
 /// What `create` needs.
@@ -14,9 +14,6 @@ pub struct Request<'a> {
     pub project: &'a str,
     pub version: &'a str,
     pub published_at: Option<&'a str>,
-    pub prerelease: bool,
-    pub channel: Option<&'a str>,
-    pub version_order: VersionOrder,
     pub source: Option<Source>,
     pub artifacts: Vec<ArtifactInput<'a>>,
     /// Completions, man pages, CLI specs, skills, desktop entries, icons,
@@ -45,9 +42,6 @@ impl<'a> Request<'a> {
             project,
             version,
             published_at: None,
-            prerelease: false,
-            channel: None,
-            version_order: VersionOrder::Source,
             source: None,
             artifacts: Vec::new(),
             resources: Vec::new(),
@@ -375,9 +369,6 @@ pub fn create(request: &Request<'_>) -> Result<Created, Error> {
             project: request.project.into(),
             version: request.version.into(),
             published_at,
-            prerelease: request.prerelease,
-            channel: request.channel.map(str::to_string),
-            version_order: request.version_order,
             source: request.source.clone(),
             artifacts,
             resources,
@@ -413,7 +404,6 @@ pub struct ListRequest<'a> {
     /// How long the list stays current.
     pub valid_for: std::time::Duration,
     pub sequence: u64,
-    pub version_order: VersionOrder,
     pub releases: Vec<ListedRelease<'a>>,
     pub identity: Identity,
 }
@@ -483,8 +473,6 @@ pub fn create_release_list(request: &ListRequest<'_>) -> Result<CreatedList, Err
             version: statement.predicate.version,
             published_at: statement.predicate.published_at,
             packslip: listed.url.to_string(),
-            prerelease: statement.predicate.prerelease,
-            channel: statement.predicate.channel,
             status: listed
                 .yanked
                 .is_some()
@@ -503,7 +491,6 @@ pub fn create_release_list(request: &ListRequest<'_>) -> Result<CreatedList, Err
             expires_at: expires.to_string(),
             sequence: request.sequence,
             identity: request.identity.clone(),
-            version_order: request.version_order,
             releases,
         },
     };
@@ -954,7 +941,6 @@ mod tests {
             generated_at: Some("2026-09-01T01:00:00Z"),
             valid_for: std::time::Duration::from_secs(30 * 86_400),
             sequence: 3,
-            version_order: VersionOrder::Source,
             releases: vec![ListedRelease {
                 url: "https://dl.example.com/1.0.0/packslip.sigstore.json",
                 bundle_path: &bundle_path,
@@ -997,7 +983,6 @@ mod tests {
             generated_at: None,
             valid_for: std::time::Duration::from_secs(60),
             sequence: 4,
-            version_order: VersionOrder::Source,
             releases: vec![
                 ListedRelease {
                     url: "https://x/a.sigstore.json",
@@ -1021,7 +1006,6 @@ mod tests {
             generated_at: None,
             valid_for: std::time::Duration::from_secs(60),
             sequence: 1,
-            version_order: VersionOrder::Source,
             releases: vec![ListedRelease {
                 url: "https://x/packslip.sigstore.json",
                 bundle_path: &bundle_path,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub mod verify;
 pub use model::{
     Artifact, Attestor, Bin, Evidence, Identity, Predicate, ReleaseList, ReleaseListStatement,
     ReleaseRef, ReleaseStatus, Requires, Resource, ResourceSource, Scheme, Source, Statement,
-    Subject, VersionOrder,
+    Subject,
 };
 pub use sigstore::{Policy, Signer, Trust};
 pub use verify::{Options, Verified, VerifiedList, verify, verify_release_list};

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use packslip::create::{ArtifactInput, AssetInput, ListRequest, ListedRelease, Re
 use packslip::minisign::{PublicKey, SecretKey, key_id_hex};
 use packslip::model::{
     Attestor, Bin, Evidence, RELEASES_PREDICATE_TYPE, ReleaseListStatement, Resource, Source,
-    Statement, VersionOrder,
+    Statement,
 };
 use packslip::sigstore::{self, Policy, Signer, Trust};
 use packslip::verify::Options;
@@ -233,24 +233,6 @@ impl std::str::FromStr for AttestorArg {
     }
 }
 
-/// `source` or `semver`, as mise's registry spells them.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct VersionOrderArg(VersionOrder);
-
-impl std::str::FromStr for VersionOrderArg {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "source" => Ok(VersionOrderArg(VersionOrder::Source)),
-            "semver" => Ok(VersionOrderArg(VersionOrder::Semver)),
-            other => Err(format!(
-                "--version-order must be source or semver, got {other:?}"
-            )),
-        }
-    }
-}
-
 /// Resolve who signs from the shared signing flags.
 fn signer(key: &Option<PathBuf>, sign: Option<SignWith>, no_log: bool) -> Result<Signer> {
     let sign_with = sign.unwrap_or(if key.is_some() {
@@ -333,17 +315,6 @@ struct Create {
     /// RFC 3339 publish time; defaults to now
     #[usage(long)]
     published_at: Option<String>,
-    /// Mark the release as not for general use
-    #[usage(long)]
-    prerelease: bool,
-    /// The release channel: stable, beta, nightly
-    #[usage(long)]
-    channel: Option<String>,
-    /// How consumers order this project's versions: source (the release
-    /// list's order, the default) or semver (strict MAJOR.MINOR.PATCH,
-    /// calver included)
-    #[usage(long)]
-    version_order: Option<VersionOrderArg>,
     /// URL of the release notes
     #[usage(long)]
     notes_url: Option<String>,
@@ -557,9 +528,6 @@ impl RunWith<BinInfo> for Create {
         });
         let created = packslip::create::create(&Request {
             published_at: self.published_at.as_deref(),
-            prerelease: self.prerelease,
-            channel: self.channel.as_deref(),
-            version_order: self.version_order.map(|v| v.0).unwrap_or_default(),
             source,
             artifacts,
             resources,
@@ -676,10 +644,6 @@ struct Releases {
     /// Increases with every list published
     #[usage(long)]
     sequence: u64,
-    /// How consumers order the listed versions: source (this list's order,
-    /// the default) or semver
-    #[usage(long)]
-    version_order: Option<VersionOrderArg>,
     /// How long the list stays current: 30d, 12h, 2w
     #[usage(long, default = "30d")]
     valid_for: String,
@@ -748,7 +712,6 @@ impl RunWith<BinInfo> for Releases {
             generated_at: self.generated_at.as_deref(),
             valid_for: parse_duration(&self.valid_for)?,
             sequence: self.sequence,
-            version_order: self.version_order.map(|v| v.0).unwrap_or_default(),
             releases,
             identity: signer.identity(),
         })?;
@@ -943,10 +906,10 @@ impl RunWith<BinInfo> for Verify {
                         "ok: {} {}{} published {} signed by {} ({}){}{} ({} of {} artifact(s) checked{}{})",
                         verified.project,
                         verified.version,
-                        if verified.prerelease {
-                            " (prerelease)"
-                        } else {
-                            ""
+                        match (&verified.channel, verified.prerelease) {
+                            (Some(channel), _) => format!(" ({channel} prerelease)"),
+                            (None, true) => " (prerelease)".to_string(),
+                            (None, false) => String::new(),
                         },
                         verified.published_at,
                         verified.key_id,

--- a/src/model.rs
+++ b/src/model.rs
@@ -51,18 +51,12 @@ pub struct Predicate {
     /// expected to have signed them. A tool in a monorepo adds a subpath:
     /// `github.com/oxc-project/oxc/oxlint`.
     pub project: String,
+    /// Semver 2.0.0 (calver such as `2026.9.1` qualifies). Its prerelease
+    /// part, if any, marks a prerelease, and the first identifier of that
+    /// part names the channel: see [`channel`].
     pub version: String,
     /// RFC 3339 UTC.
     pub published_at: String,
-    /// A release not meant for general use.
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub prerelease: bool,
-    /// `stable`, `beta`, `nightly`, or whatever the vendor calls it.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub channel: Option<String>,
-    /// How consumers order this project's versions.
-    #[serde(default, skip_serializing_if = "VersionOrder::is_source")]
-    pub version_order: VersionOrder,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<Source>,
     pub artifacts: Vec<Artifact>,
@@ -112,35 +106,22 @@ impl std::fmt::Display for Attestor {
     }
 }
 
-/// How a project's versions are ordered, in mise's vocabulary. The vendor
-/// declares it; consumers never infer it from the strings.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "kebab-case")]
-pub enum VersionOrder {
-    /// The order the release list gives, newest first: GitHub's releases
-    /// endpoint, or the vendor's signed list. For date versions,
-    /// two-component versions, mixed histories, and anything uncertain.
-    #[default]
-    Source,
-    /// Versions are strict `MAJOR.MINOR.PATCH` (calver such as `2026.9.1`
-    /// included) and sort as semver, so the highest is the latest and
-    /// range constraints have meaning.
-    Semver,
+/// Parse a version as packslip requires: semver 2.0.0, so that precedence
+/// ranks releases and the prerelease part says the rest.
+pub fn parse_version(version: &str) -> Result<semver::Version, InvalidDocument> {
+    if version.is_empty() {
+        return Err(InvalidDocument::Version);
+    }
+    semver::Version::parse(version).map_err(|_| InvalidDocument::NotSemver(version.to_string()))
 }
 
-impl VersionOrder {
-    pub fn is_source(&self) -> bool {
-        *self == VersionOrder::Source
-    }
-}
-
-impl std::fmt::Display for VersionOrder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
-            VersionOrder::Source => "source",
-            VersionOrder::Semver => "semver",
-        })
-    }
+/// The channel a version is on: the first identifier of its prerelease
+/// part, when that is not a number. `1.3.0-nightly.20260904` is on
+/// `nightly` and `1.2.0-beta.2` on `beta`; `1.2.0` and `1.2.0-1` are on
+/// none.
+pub fn channel(version: &semver::Version) -> Option<&str> {
+    let first = version.pre.as_str().split('.').next()?;
+    (!first.is_empty() && !first.bytes().all(|b| b.is_ascii_digit())).then_some(first)
 }
 
 /// One thing a repackager checked. Documented kinds:
@@ -455,10 +436,7 @@ pub struct ReleaseList {
     /// than it has seen.
     pub sequence: u64,
     pub identity: Identity,
-    /// How consumers order the versions listed.
-    #[serde(default, skip_serializing_if = "VersionOrder::is_source")]
-    pub version_order: VersionOrder,
-    /// Newest first: under `source` ordering this order is the ranking.
+    /// In any order; consumers rank by semver precedence.
     pub releases: Vec<ReleaseRef>,
 }
 
@@ -470,10 +448,6 @@ pub struct ReleaseRef {
     /// URL of the release's `packslip.sigstore.json`. The statement's
     /// subject of the same name carries that file's digest.
     pub packslip: String,
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub prerelease: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub channel: Option<String>,
     /// Set when the vendor withdrew the release. Consumers never select a
     /// yanked release and warn when they hold one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -514,6 +488,10 @@ pub enum InvalidDocument {
     Project(String),
     #[error("version must not be empty")]
     Version,
+    #[error(
+        "version must be semver 2.0.0 (MAJOR.MINOR.PATCH, with an optional prerelease part), got {0:?}"
+    )]
+    NotSemver(String),
     #[error("{field} must be RFC 3339, got {value:?}")]
     Timestamp { field: &'static str, value: String },
     #[error("artifact {0:?} appears more than once")]
@@ -645,9 +623,7 @@ impl Statement {
         if !valid_project(&p.project) {
             return Err(InvalidDocument::Project(p.project.clone()));
         }
-        if p.version.is_empty() {
-            return Err(InvalidDocument::Version);
-        }
+        parse_version(&p.version)?;
         check_timestamp("published_at", &p.published_at)?;
         if p.artifacts.is_empty() {
             return Err(InvalidDocument::NoArtifacts);
@@ -814,9 +790,7 @@ impl ReleaseListStatement {
         }
         let mut seen = std::collections::BTreeSet::new();
         for release in &p.releases {
-            if release.version.is_empty() {
-                return Err(InvalidDocument::Version);
-            }
+            parse_version(&release.version)?;
             if !seen.insert(release.version.as_str()) {
                 return Err(InvalidDocument::DuplicateRelease(release.version.clone()));
             }
@@ -925,9 +899,6 @@ mod tests {
                 project: "github.com/jdx/mise".into(),
                 version: "2026.9.1".into(),
                 published_at: "2026-09-01T12:00:00Z".into(),
-                prerelease: false,
-                channel: None,
-                version_order: VersionOrder::Semver,
                 source: Some(Source {
                     repo: "https://github.com/jdx/mise".into(),
                     commit: Some("b".repeat(40)),
@@ -981,7 +952,6 @@ mod tests {
                     key_id: "5A0A0B8B9C6D7E1F".into(),
                     issuer: None,
                 },
-                version_order: VersionOrder::Source,
                 releases: vec![ReleaseRef {
                     version: "2026.9.1".into(),
                     published_at: "2026-09-01T12:00:00Z".into(),
@@ -1011,23 +981,50 @@ mod tests {
             json.starts_with(r#"{"_type":"https://in-toto.io/Statement/v1","subject""#),
             "{json}"
         );
-        assert!(!json.contains("prerelease"), "defaults are omitted: {json}");
-        assert!(json.contains(r#""version_order":"semver""#), "{json}");
-        assert!(!json.contains("attested_by"), "{json}");
+        assert!(
+            !json.contains("attested_by"),
+            "defaults are omitted: {json}"
+        );
         assert!(json.contains(r#""bin":["mise/bin/mise"]"#), "{json}");
         assert_eq!(serde_json::from_str::<Statement>(&json).unwrap(), s);
     }
 
     #[test]
     fn a_v0_2_document_round_trips_byte_for_byte() {
-        let old = r#"{"_type":"https://in-toto.io/Statement/v1","subject":[{"name":"t-linux-x64.tar.xz","digest":{"sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}],"predicateType":"https://packslip.dev/release/v1","predicate":{"project":"github.com/o/r","version":"1","published_at":"2026-09-01T00:00:00Z","artifacts":[{"name":"t-linux-x64.tar.xz","os":"linux","arch":"x86_64","libc":"gnu","size":5,"format":"tar.xz","bin":["t"]}],"identity":{"scheme":"sigstore-oidc","key_id":"https://github.com/o/r/.github/workflows/r.yml@refs/tags/v1","issuer":"https://token.actions.githubusercontent.com"}}}"#;
+        let old = r#"{"_type":"https://in-toto.io/Statement/v1","subject":[{"name":"t-linux-x64.tar.xz","digest":{"sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}],"predicateType":"https://packslip.dev/release/v1","predicate":{"project":"github.com/o/r","version":"1.0.0","published_at":"2026-09-01T00:00:00Z","artifacts":[{"name":"t-linux-x64.tar.xz","os":"linux","arch":"x86_64","libc":"gnu","size":5,"format":"tar.xz","bin":["t"]}],"identity":{"scheme":"sigstore-oidc","key_id":"https://github.com/o/r/.github/workflows/r.yml@refs/tags/v1","issuer":"https://token.actions.githubusercontent.com"}}}"#;
         let parsed: Statement = serde_json::from_str(old).unwrap();
         parsed.validate().unwrap();
         assert_eq!(parsed.predicate.attested_by, Attestor::Vendor);
-        assert_eq!(parsed.predicate.version_order, VersionOrder::Source);
-        assert!(!parsed.predicate.prerelease);
         assert_eq!(parsed.predicate.artifacts[0].bin, [Bin::new("t")]);
         assert_eq!(String::from_utf8(parsed.canonical_bytes()).unwrap(), old);
+    }
+
+    #[test]
+    fn versions_are_semver_and_name_their_channel() {
+        for bad in ["", "1", "1.2", "v1.2.3", "1.2.3.4", "2026-09-04", "nightly"] {
+            assert!(parse_version(bad).is_err(), "{bad:?} should be refused");
+        }
+        let cases = [
+            ("1.2.3", false, None),
+            ("2026.9.1", false, None),
+            ("1.2.3+build.5", false, None),
+            ("1.2.0-rc.1", true, Some("rc")),
+            ("1.2.0-beta.2", true, Some("beta")),
+            ("1.3.0-nightly.20260904", true, Some("nightly")),
+            ("1.2.0-1", true, None),
+            ("1.2.0-0.3.7", true, None),
+        ];
+        for (text, prerelease, expected) in cases {
+            let version = parse_version(text).unwrap();
+            assert_eq!(!version.pre.is_empty(), prerelease, "{text}");
+            assert_eq!(channel(&version), expected, "{text}");
+        }
+        let mut doc = sample();
+        doc.predicate.version = "1.2".into();
+        assert!(matches!(
+            doc.validate(),
+            Err(InvalidDocument::NotSemver(v)) if v == "1.2"
+        ));
     }
 
     #[test]

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -29,8 +29,9 @@ pub struct Verified {
     pub key_id: String,
     /// Whether the vendor or a repackager made the claim.
     pub attested_by: crate::model::Attestor,
-    pub version_order: crate::model::VersionOrder,
+    /// Whether the version has a prerelease part.
     pub prerelease: bool,
+    /// The channel the version's prerelease part names, if any.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub channel: Option<String>,
     /// The OIDC issuer, for `sigstore-oidc`.
@@ -150,6 +151,7 @@ pub fn verify(
     let verified = sigstore::verify(bundle, trust, options.require_log, options.trusted_root)?;
     let statement: Statement = serde_json::from_slice(&verified.statement)?;
     statement.validate()?;
+    let version = crate::model::parse_version(&statement.predicate.version)?;
     let (scheme, key_id, issuer) =
         check_declared(&statement.predicate.identity, &verified.signed_by)?;
     let mut checked = Vec::new();
@@ -198,9 +200,8 @@ pub fn verify(
         scheme,
         key_id,
         attested_by: statement.predicate.attested_by,
-        version_order: statement.predicate.version_order,
-        prerelease: statement.predicate.prerelease,
-        channel: statement.predicate.channel.clone(),
+        prerelease: !version.pre.is_empty(),
+        channel: crate::model::channel(&version).map(str::to_string),
         issuer,
         logged_at: logged_at(verified.integrated_time),
         provenance_linked: statement.provenance_linked(),

--- a/static/schema/release-v1.json
+++ b/static/schema/release-v1.json
@@ -191,13 +191,6 @@
           "$ref": "#/$defs/Attestor",
           "description": "Who is making the claim: the vendor itself, or a repackager that\nchecked the vendor's evidence and signed a document about it."
         },
-        "channel": {
-          "description": "`stable`, `beta`, `nightly`, or whatever the vendor calls it.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "evidence": {
           "description": "What a repackager checked before signing.",
           "items": {
@@ -213,10 +206,6 @@
             "string",
             "null"
           ]
-        },
-        "prerelease": {
-          "description": "A release not meant for general use.",
-          "type": "boolean"
         },
         "project": {
           "description": "The project's name: a host path such as `github.com/jdx/mise` or\n`mise.jdx.dev`. The host is where a\nconsumer discovers releases and, for forge hosts, what identity is\nexpected to have signed them. A tool in a monorepo adds a subpath:\n`github.com/oxc-project/oxc/oxlint`.",
@@ -250,11 +239,8 @@
           ]
         },
         "version": {
+          "description": "Semver 2.0.0 (calver such as `2026.9.1` qualifies). Its prerelease\npart, if any, marks a prerelease, and the first identifier of that\npart names the channel: see [`channel`].",
           "type": "string"
-        },
-        "version_order": {
-          "$ref": "#/$defs/VersionOrder",
-          "description": "How consumers order this project's versions."
         }
       },
       "required": [
@@ -419,21 +405,6 @@
         "digest"
       ],
       "type": "object"
-    },
-    "VersionOrder": {
-      "description": "How a project's versions are ordered, in mise's vocabulary. The vendor\ndeclares it; consumers never infer it from the strings.",
-      "oneOf": [
-        {
-          "const": "source",
-          "description": "The order the release list gives, newest first: GitHub's releases\nendpoint, or the vendor's signed list. For date versions,\ntwo-component versions, mixed histories, and anything uncertain.",
-          "type": "string"
-        },
-        {
-          "const": "semver",
-          "description": "Versions are strict `MAJOR.MINOR.PATCH` (calver such as `2026.9.1`\nincluded) and sort as semver, so the highest is the latest and\nrange constraints have meaning.",
-          "type": "string"
-        }
-      ]
     }
   },
   "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/static/schema/releases-v1.json
+++ b/static/schema/releases-v1.json
@@ -61,7 +61,7 @@
           "type": "string"
         },
         "releases": {
-          "description": "Newest first: under `source` ordering this order is the ranking.",
+          "description": "In any order; consumers rank by semver precedence.",
           "items": {
             "$ref": "#/$defs/ReleaseRef"
           },
@@ -72,10 +72,6 @@
           "format": "uint64",
           "minimum": 0,
           "type": "integer"
-        },
-        "version_order": {
-          "$ref": "#/$defs/VersionOrder",
-          "description": "How consumers order the versions listed."
         }
       },
       "required": [
@@ -90,18 +86,9 @@
     },
     "ReleaseRef": {
       "properties": {
-        "channel": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "packslip": {
           "description": "URL of the release's `packslip.sigstore.json`. The statement's\nsubject of the same name carries that file's digest.",
           "type": "string"
-        },
-        "prerelease": {
-          "type": "boolean"
         },
         "published_at": {
           "description": "RFC 3339 UTC, copied from the release's packslip.",
@@ -173,21 +160,6 @@
         "digest"
       ],
       "type": "object"
-    },
-    "VersionOrder": {
-      "description": "How a project's versions are ordered, in mise's vocabulary. The vendor\ndeclares it; consumers never infer it from the strings.",
-      "oneOf": [
-        {
-          "const": "source",
-          "description": "The order the release list gives, newest first: GitHub's releases\nendpoint, or the vendor's signed list. For date versions,\ntwo-component versions, mixed histories, and anything uncertain.",
-          "type": "string"
-        },
-        {
-          "const": "semver",
-          "description": "Versions are strict `MAJOR.MINOR.PATCH` (calver such as `2026.9.1`\nincluded) and sort as semver, so the highest is the latest and\nrange constraints have meaning.",
-          "type": "string"
-        }
-      ]
     }
   },
   "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -352,6 +352,27 @@ fn variants_urls_evidence_and_monorepo_names() {
     assert_ne!(code, 0);
     assert!(err.contains("give one a variant"), "{err}");
 
+    let (code, _, err) = packslip(
+        d,
+        &[
+            "create",
+            "--project",
+            "github.com/oxc-project/oxc/oxlint",
+            "--version",
+            "1.0",
+            "--key",
+            "k.key",
+            "--no-log",
+            "--out",
+            "dist",
+            "--bin",
+            "oxlint",
+            "oxlint-linux-x64.tar.gz",
+        ],
+    );
+    assert_ne!(code, 0);
+    assert!(err.contains("semver"), "{err}");
+
     let (code, out, err) = packslip(
         d,
         &[
@@ -359,7 +380,7 @@ fn variants_urls_evidence_and_monorepo_names() {
             "--project",
             "github.com/oxc-project/oxc/oxlint",
             "--version",
-            "1.0.0",
+            "1.0.0-beta.1",
             "--key",
             "k.key",
             "--no-log",
@@ -371,11 +392,6 @@ fn variants_urls_evidence_and_monorepo_names() {
             "oxlint-linux-arm64=https://cdn.example.com/oxlint-linux-arm64",
             "--bin",
             "oxlint=bin/oxlint-x86_64",
-            "--prerelease",
-            "--channel",
-            "beta",
-            "--version-order",
-            "semver",
             "--notes-url",
             "https://github.com/oxc-project/oxc/releases/tag/oxlint_v1.0.0",
             "--source-repo",
@@ -403,9 +419,9 @@ fn variants_urls_evidence_and_monorepo_names() {
     assert_eq!(arts[2]["url"], "https://cdn.example.com/oxlint-linux-arm64");
     assert_eq!(arts[0]["bin"][0]["name"], "oxlint");
     assert_eq!(arts[0]["bin"][0]["path"], "bin/oxlint-x86_64");
-    assert_eq!(doc["predicate"]["prerelease"], true);
-    assert_eq!(doc["predicate"]["channel"], "beta");
-    assert_eq!(doc["predicate"]["version_order"], "semver");
+    assert_eq!(doc["predicate"]["version"], "1.0.0-beta.1");
+    assert!(doc["predicate"].get("prerelease").is_none());
+    assert!(doc["predicate"].get("channel").is_none());
     assert_eq!(doc["predicate"]["source"]["tag"], "oxlint_v1.0.0");
     assert_eq!(
         doc["subject"][0]["digest"]["sha512"].as_str().map(str::len),
@@ -427,7 +443,9 @@ fn variants_urls_evidence_and_monorepo_names() {
     );
     assert_eq!(code, 0, "{err}");
     assert!(
-        out.starts_with("ok: github.com/oxc-project/oxc/oxlint 1.0.0 (prerelease) published"),
+        out.starts_with(
+            "ok: github.com/oxc-project/oxc/oxlint 1.0.0-beta.1 (beta prerelease) published"
+        ),
         "{out}"
     );
 
@@ -439,7 +457,7 @@ fn variants_urls_evidence_and_monorepo_names() {
             "--project",
             "packages.example.com/tool",
             "--version",
-            "2.0",
+            "2.0.0",
             "--key",
             "k.key",
             "--no-log",
@@ -459,7 +477,7 @@ fn variants_urls_evidence_and_monorepo_names() {
             "--project",
             "packages.example.com/tool",
             "--version",
-            "2.0",
+            "2.0.0",
             "--key",
             "k.key",
             "--no-log",


### PR DESCRIPTION
Stacked on #17 (merged), so this is against `main`.

## Why

GitHub's immutable releases lock a release's assets and tag once it is published, but leave the prerelease flag, latest mark, and notes editable. A packslip is one of those locked assets, so a `prerelease` or `channel` field signed into it could never follow a release candidate that gets promoted. It would be either frozen or contradicted by GitHub's own flag.

## What

- `version` must be semver 2.0.0 (calver such as `2026.9.1` qualifies). `create`, `releases`, and `verify` refuse anything else.
- `prerelease` and `channel` are gone from the release predicate. A prerelease is a version with a prerelease part; the channel is that part's first identifier when it is not a number (`1.3.0-nightly.20260904` is on `nightly`, `1.2.0-1` is on none). `verify` reports both, derived.
- `version_order` is gone from both predicates, and with it the `source` ordering. Semver precedence ranks releases; the release list's order and GitHub's prerelease flag are not consulted.
- The release list entry keeps only `status`/`status_reason` and `security`.
- The GitHub Action drops its `prerelease` and `channel` inputs. It had been copying the release event's flag into the signed document, which is exactly the trap.
- The spec's Discovery section now says to yank a GitHub release by deleting it, since an immutable release's packslip asset cannot be removed.
- Spec section "Ordering versions" becomes "Versions" and explains the reasoning; site page, index, field reference, and schemas updated to match.

## Tests

Model tests cover accepted and refused version strings and channel derivation; the CLI test creates `1.0.0-beta.1`, checks the fields are absent from the document, and checks `verify` prints `(beta prerelease)`. A non-semver `--version` is refused with a message naming semver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking predicate and consumer contract changes affect every publisher and installer that relied on opaque versions, `version_order`, or document-level prerelease/channel flags.
> 
> **Overview**
> This is a **breaking format and tooling change**: release identity is now carried only by a semver `version` string, with ordering and release-track semantics inferred from that string instead of separate signed fields or list order.
> 
> **Schema and behavior.** `prerelease`, `channel`, and `version_order` are removed from release and release-list predicates. `version` must be semver 2.0.0 (calver like `2026.9.1` still works); `create`, validation, and `verify` reject invalid strings. Prerelease status and channel come from the prerelease segment (`channel()` uses the first non-numeric identifier). Consumers always rank by semver precedence; GitHub list order and the GitHub prerelease flag are no longer part of the spec.
> 
> **Tooling and integration.** CLI flags `--prerelease`, `--channel`, and `--version-order` are dropped from `create` and `releases`. The GitHub Action no longer accepts `prerelease`/`channel` or maps the release event’s prerelease flag into the bundle. `verify` still reports prerelease/channel, but derives them at read time; human output can show forms like `(beta prerelease)`.
> 
> **Docs and tests.** Spec section "Ordering versions" becomes **Versions**; JSON schemas, site copy, and usage specs align. Tests cover semver refusal, channel derivation, and CLI flows using versions such as `1.0.0-beta.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b3e40ba6963cf2035ed0704e5c8a8184bd8eeef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->