### PR TITLE
docs: add syntax highlighting

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -3,6 +3,10 @@ locale = "en-US"
 title = "packslip"
 disableKinds = ["rss", "sitemap", "taxonomy", "term"]
 
+[markup]
+  [markup.highlight]
+    noClasses = false
+
 [caches]
   [caches.images]
     dir = ":cacheDir/images"

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -193,11 +193,13 @@
 
   <h2 id="repackager">Repackager attestation</h2>
   <p>A repository or mirror that redistributes a vendor's artifacts, and whose vendor publishes no packslip, may sign one itself with <code>"attested_by": "repackager"</code>. The <code>project</code> still names the vendor's project and the artifacts are still the vendor's files, but <code>identity</code> is the repackager's, and <code>evidence</code> says what it checked before signing:</p>
-{{ highlight `"attested_by": "repackager",
-"evidence": [
-  { "kind": "apt-release-gpg", "detail": "3FEF9748469ADBE15DA7CA80AC2D62742012EA22" },
-  { "kind": "pkgbuild-checksums" }
-]` "json" "" }}
+{{ highlight `{
+  "attested_by": "repackager",
+  "evidence": [
+    { "kind": "apt-release-gpg", "detail": "3FEF9748469ADBE15DA7CA80AC2D62742012EA22" },
+    { "kind": "pkgbuild-checksums" }
+  ]
+}` "json" "" }}
   <p>Documented kinds: <code>pkgbuild-checksums</code> (digests matched the packaging the repackager maintains), <code>checksum-file-over-tls</code> (the vendor's checksum file, unsigned), <code>apt-release-gpg</code> (an apt index signed with the given key), <code>vendor-signature</code> (a detached signature the vendor publishes), <code>github-attestation</code> (GitHub artifact attestations verified), <code>none</code>.</p>
   <p>A repackager document proves that the repackager published exactly these digests and checked the listed evidence. It does not prove anything the vendor did not sign. Consumers rank it below a vendor document, and a consumer that already holds a vendor document for a project refuses to replace it with a repackager one without a human's say-so.</p>
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -63,7 +63,7 @@
   <p>The bundle carries the statement, so the signed bytes are exactly the payload bytes and a consumer needs no canonicalization step. <code>packslip show</code> prints them; so does <code>jq -r .dsseEnvelope.payload | base64 -d</code>. <code>cosign</code> and <code>gh attestation</code> understand the bundle as-is.</p>
 
   <h2 id="document">The release statement</h2>
-<pre><code>{
+{{ highlight `{
   "_type": "https://in-toto.io/Statement/v1",
   "subject": [
     { "name": "mise-v2026.9.1-linux-x64.tar.xz",
@@ -101,7 +101,7 @@
     "notes_url": "https://github.com/jdx/mise/releases/tag/v2026.9.1",
     "sbom": "https://.../sbom.cdx.json"
   }
-}</code></pre>
+}` "json" "" }}
   <p>Rules:</p>
   <ul>
     <li><code>subject</code> lists every artifact by file name with its digests, plus any separate file a resource comes from. <code>artifacts</code> carries the same names with platform, size, download URL, format, executables, requirements, and provenance links. Every artifact is a subject, every subject is an artifact or a resource's <code>asset</code>, and neither list contains a duplicate. At least one artifact is required. <code>sha256</code> is required and is 64 lowercase hex characters; <code>sha512</code> is optional and 128.</li>
@@ -193,11 +193,11 @@
 
   <h2 id="repackager">Repackager attestation</h2>
   <p>A repository or mirror that redistributes a vendor's artifacts, and whose vendor publishes no packslip, may sign one itself with <code>"attested_by": "repackager"</code>. The <code>project</code> still names the vendor's project and the artifacts are still the vendor's files, but <code>identity</code> is the repackager's, and <code>evidence</code> says what it checked before signing:</p>
-<pre><code>"attested_by": "repackager",
+{{ highlight `"attested_by": "repackager",
 "evidence": [
   { "kind": "apt-release-gpg", "detail": "3FEF9748469ADBE15DA7CA80AC2D62742012EA22" },
   { "kind": "pkgbuild-checksums" }
-]</code></pre>
+]` "json" "" }}
   <p>Documented kinds: <code>pkgbuild-checksums</code> (digests matched the packaging the repackager maintains), <code>checksum-file-over-tls</code> (the vendor's checksum file, unsigned), <code>apt-release-gpg</code> (an apt index signed with the given key), <code>vendor-signature</code> (a detached signature the vendor publishes), <code>github-attestation</code> (GitHub artifact attestations verified), <code>none</code>.</p>
   <p>A repackager document proves that the repackager published exactly these digests and checked the listed evidence. It does not prove anything the vendor did not sign. Consumers rank it below a vendor document, and a consumer that already holds a vendor document for a project refuses to replace it with a repackager one without a human's say-so.</p>
 
@@ -218,7 +218,7 @@
     <li>Any other project publishes a signed list at <code>https://&lt;host&gt;/.well-known/packslip/&lt;path&gt;.json</code>, where <code>&lt;path&gt;</code> is the project name after the host, or <code>packslip.json</code> directly under <code>.well-known</code> when the name is a bare host.</li>
   </ul>
   <p>The list is required: a consumer that finds none refuses the project rather than guessing at URLs. It is a bundle of the same shape as a packslip, with the <code>releases/v1</code> predicate:</p>
-<pre><code>{
+{{ highlight `{
   "_type": "https://in-toto.io/Statement/v1",
   "subject": [
     { "name": "https://dl.example.com/2026.9.1/packslip.sigstore.json",
@@ -242,7 +242,7 @@
         "status": "yanked", "status_reason": "CVE-2026-1234" }
     ]
   }
-}</code></pre>
+}` "json" "" }}
   <p>Each subject is a listed packslip's URL with the digest of that file, so the list pins the exact documents it points at. <code>expires_at</code> and <code>sequence</code> are borrowed from TUF's timestamp role: a consumer refuses a list that has expired, or whose sequence is lower than one it has already accepted, so a mirror cannot freeze or roll back the vendor's view.</p>
   <p>Each entry may carry <code>status: "yanked"</code> with a <code>status_reason</code> when the vendor withdrew the release, and <code>security: true</code> when it fixes a vulnerability. A consumer never selects a yanked release, warns when it holds one, and may shorten its minimum release age for a security release. Nothing else about a release lives on the list: its version says the rest.</p>
   <p><code>packslip releases</code> produces the list from local copies of the released bundles. The list separates the name from where the bytes live: the identity is anchored to the domain, and the artifacts can be anywhere.</p>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -96,10 +96,10 @@
     <div class="step">
       <h3>The release job signs it</h3>
       <p>Add one step after the artifacts are built. It attests their build provenance, hashes them, reads each platform from the file name, and signs the manifest through sigstore with the workflow's own identity. No secret is created or stored.</p>
-<pre><code>- uses: jdx/packslip@v1
+{{ highlight `- uses: jdx/packslip@v1
   with:
     artifacts: dist/*
-    bin: mise</code></pre>
+    bin: mise` "yaml" "" }}
     </div>
     <div class="step">
       <h3>One file ships beside the artifacts</h3>
@@ -108,8 +108,8 @@
     <div class="step">
       <h3>The consumer checks the name</h3>
       <p>A packslip for <code>github.com/jdx/mise</code> must be signed by a workflow of that repository through GitHub's issuer. The project name is the pin, so there is nothing to configure or look up before the first install.</p>
-<pre><code>packslip verify packslip.sigstore.json \
-  --artifact mise-v2026.9.1-linux-x64.tar.xz</code></pre>
+{{ highlight `packslip verify packslip.sigstore.json \
+  --artifact mise-v2026.9.1-linux-x64.tar.xz` "shell" "" }}
     </div>
   </div>
   <div class="prose" style="margin-top:2rem">
@@ -162,7 +162,7 @@
     <div>
       <h3>For vendors on GitHub</h3>
       <p>Add the action to the job that publishes your release, after the artifacts exist.</p>
-<pre><code>permissions:
+{{ highlight `permissions:
   contents: write
   id-token: write
   attestations: write
@@ -171,12 +171,12 @@ steps:
   - uses: jdx/packslip@v1
     with:
       artifacts: dist/*.tar.xz dist/*.zip
-      bin: mytool</code></pre>
+      bin: mytool` "yaml" "" }}
       <p>The action attests build provenance for every artifact, writes the packslip, signs it with the job's identity, verifies the result, and uploads <code>packslip.sigstore.json</code> to the release.</p>
       <p>Most fields are detected. The project name comes from the repository, the version from the tag, and each artifact's os, arch, libc, and format from its file name. Anything the defaults cannot know is an input: the executables inside the archives, a variant name for two builds of one platform, and the completions, man page, <a href="https://usage.jdx.dev">usage</a> spec, skill, or desktop entry that ship alongside. A repository with several tools runs the step once per tool with a subpath in the project name. The <a href="/release/v1/#tooling">tooling section of the spec</a> lists every option.</p>
       <h3>Everywhere else</h3>
       <p>Outside GitHub, run the <code>packslip</code> CLI directly. In any CI system that issues OIDC tokens it signs keylessly. Anywhere else, generate a key pair once, keep the private key in your secret store, and publish the public key so consumers can pin it. Either way the signature is logged to Rekor.</p>
-<pre><code>cargo install packslip
+{{ highlight `cargo install packslip
 
 packslip keygen -o release.key
 packslip create \
@@ -191,7 +191,7 @@ packslip create \
 packslip releases --project mytool.example.com \
   --sequence 42 --valid-for 30d --key release.key \
   --release "https://dl.example.com/mytool/$VERSION/packslip.sigstore.json=dist/packslip.sigstore.json" \
-  --out site/.well-known/packslip.json</code></pre>
+  --out site/.well-known/packslip.json` "shell" "" }}
     </div>
     <div id="consumers">
       <h3>For consumers</h3>
@@ -204,7 +204,7 @@ packslip releases --project mytool.example.com \
         <li><strong>Order by semver.</strong> Every version is semver: precedence ranks releases, a prerelease part marks a prerelease, and its first identifier names the channel. Every project has a release list: GitHub's releases endpoint, or a signed list on the vendor's domain. It only says what was released and what was withdrawn. Refuse a stale signed list, never pick a yanked release, and skip prereleases unless asked.</li>
         <li><strong>Never guess between two artifacts.</strong> Select by os, arch, libc, format, and variant. If two still match, fail instead of picking one.</li>
       </ol>
-<pre><code>packslip verify packslip.sigstore.json \
+{{ highlight `packslip verify packslip.sigstore.json \
   --artifact mise-v2026.9.1-linux-x64.tar.xz --json
 {
   "project": "github.com/jdx/mise",
@@ -217,7 +217,7 @@ packslip releases --project mytool.example.com \
   "provenance_linked": true,
   "checked_artifacts": ["mise-v2026.9.1-linux-x64.tar.xz"],
   "artifact_count": 6
-}</code></pre>
+}` "shell" "" }}
       <p>The reference verifier takes the same pins as flags: <code>--identity-prefix</code>, or an exact <code>--identity</code> and <code>--issuer</code>, for keyless signers, and <code>--pubkey</code> for a key. It is also a Rust library, and <code>packslip schema</code> prints the <a href="/schema/release-v1.json">JSON schema</a> for other implementations.</p>
     </div>
   </div>

--- a/static/style.css
+++ b/static/style.css
@@ -72,6 +72,101 @@ pre {
 
 pre code { background: none; padding: 0; font-size: inherit; }
 
+/* Hugo/Chroma syntax highlighting. Colors are tuned to the site's paper palette. */
+.chroma { color: var(--ink); background: var(--paper-2); }
+.chroma .err { color: #a82418; }
+.chroma .k,
+.chroma .kc,
+.chroma .kd,
+.chroma .kn,
+.chroma .kp,
+.chroma .kr,
+.chroma .kt { color: #a82418; }
+.chroma .na,
+.chroma .nb,
+.chroma .nc,
+.chroma .nd,
+.chroma .nf,
+.chroma .nt { color: #7357a6; }
+.chroma .no,
+.chroma .nv,
+.chroma .vc,
+.chroma .vg,
+.chroma .vi,
+.chroma .vm { color: #8b4c13; }
+.chroma .s,
+.chroma .s1,
+.chroma .s2,
+.chroma .sa,
+.chroma .sb,
+.chroma .sc,
+.chroma .sd,
+.chroma .se,
+.chroma .sh,
+.chroma .si,
+.chroma .sr,
+.chroma .ss,
+.chroma .sx { color: #276749; }
+.chroma .m,
+.chroma .mb,
+.chroma .mf,
+.chroma .mh,
+.chroma .mi,
+.chroma .mo,
+.chroma .o,
+.chroma .ow { color: #245c9f; }
+.chroma .c,
+.chroma .c1,
+.chroma .ch,
+.chroma .cm,
+.chroma .cp,
+.chroma .cpf,
+.chroma .cs { color: var(--muted); font-style: italic; }
+
+@media (prefers-color-scheme: dark) {
+  .chroma .err,
+  .chroma .k,
+  .chroma .kd,
+  .chroma .kn,
+  .chroma .kr,
+  .chroma .kt { color: #ff7b72; }
+  .chroma .kc,
+  .chroma .kp,
+  .chroma .m,
+  .chroma .mb,
+  .chroma .mf,
+  .chroma .mh,
+  .chroma .mi,
+  .chroma .mo,
+  .chroma .no,
+  .chroma .nv,
+  .chroma .o,
+  .chroma .ow,
+  .chroma .vc,
+  .chroma .vg,
+  .chroma .vi,
+  .chroma .vm { color: #79c0ff; }
+  .chroma .na,
+  .chroma .nb,
+  .chroma .nd,
+  .chroma .nf { color: #d2a8ff; }
+  .chroma .nc { color: #f0883e; }
+  .chroma .nt { color: #7ee787; }
+  .chroma .s,
+  .chroma .s1,
+  .chroma .s2,
+  .chroma .sb,
+  .chroma .sc,
+  .chroma .sd,
+  .chroma .si,
+  .chroma .sr,
+  .chroma .ss,
+  .chroma .sx { color: #a5d6ff; }
+  .chroma .sa,
+  .chroma .se,
+  .chroma .sh { color: #79c0ff; }
+}
+
 .wrap {
   width: min(100% - 2.5rem, 68rem);
   margin-inline: auto;


### PR DESCRIPTION
## Summary

- enable class-based Hugo/Chroma syntax highlighting
- highlight JSON, YAML, and shell examples at build time
- add syntax colors tailored for the site’s light and dark themes

## Testing

- `mise run docs:build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and static-site styling only; no runtime, auth, or verification behavior changes.
> 
> **Overview**
> The docs site now **syntax-highlights** spec and landing-page examples at **Hugo build time** instead of rendering them as plain monospace blocks.
> 
> **Hugo** is configured for **class-based Chroma** output (`markup.highlight.noClasses = false`). **Layouts** (`single.html`, `index.html`) replace `<pre><code>` snippets with `highlight` for **JSON**, **YAML**, and **shell** examples. **CSS** adds `.chroma` token colors aligned with the existing paper palette, including **`prefers-color-scheme: dark`** overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a56574ec6f8c6aa6c04edecd42091ead12f0eda7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->