### PR TITLE
feat: reserve extensions for vendor- and consumer-defined data

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ completions, a man page, and docs with its own tooling. Desktop
 applications add `desktop`, `icon`, and `app` entries; there is no CLI or
 GUI type, since the entries say which a release is.
 
+Anything the spec has no field for goes under `extensions`, keyed by who
+defines it: `--extension 'example.com={"build_id":"20260901.3"}'` for the
+vendor's own data, or a consumer's name such as `mise` for hints that
+consumer documents. packslip never assigns meaning to a key there, so it
+cannot collide with a field a later revision adds.
+
 ## Layout
 
 - `src/`, `tests/` — the `packslip` crate: schema, generator, verifier.

--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,14 @@ inputs:
     description: URL of an SBOM for the release
     required: false
     default: ""
+  extensions:
+    description: >
+      Release-level extensions, one per line, each a `packslip create
+      --extension` value: NAME=JSON, where NAME is who defines the value (a
+      consumer such as mise, or a domain the vendor controls) and JSON is
+      the value, such as example.com={"build_id":"20260901.3"}.
+    required: false
+    default: ""
   attest:
     description: >
       Also attest SLSA build provenance for every artifact with
@@ -173,6 +181,7 @@ runs:
         IN_RESOURCES: ${{ inputs.resources }}
         IN_NOTES_URL: ${{ inputs.notes-url }}
         IN_SBOM: ${{ inputs.sbom }}
+        IN_EXTENSIONS: ${{ inputs.extensions }}
         IN_ATTEST: ${{ inputs.attest }}
         IN_OUT: ${{ inputs.out }}
         REPO: ${{ github.repository }}
@@ -208,6 +217,9 @@ runs:
           [ -n "$line" ] && args+=(--resource "$line")
         done <<< "$IN_RESOURCES"
         [ -n "$IN_SBOM" ] && args+=(--sbom "$IN_SBOM")
+        while IFS= read -r line; do
+          [ -n "$line" ] && args+=(--extension "$line")
+        done <<< "$IN_EXTENSIONS"
         mapfile -t files < "${RUNNER_TEMP}/packslip-files"
         if [ "$IN_ATTEST" = true ]; then
           # GitHub serves each artifact's provenance at the attestations API

--- a/content/cli/create.md
+++ b/content/cli/create.md
@@ -27,6 +27,7 @@ Digests every artifact, infers os/arch/libc/format from file names (override wit
 - **`--published-at <PUBLISHED_AT>`** — RFC 3339 publish time; defaults to now
 - **`--notes-url <NOTES_URL>`** — URL of the release notes
 - **`--sbom <SBOM>`** — SBOM URL
+- **`--extension <EXTENSION>`** — Release-level extension as NAME=JSON, where NAME is who defines it (a consumer such as mise, or a domain the vendor controls) and JSON is its value. Example: 'example.com={"build_id":"20260901.3"}' (repeatable)
 - **`--bin <BIN>`** — Executable inside every archive, as PATH or NAME=PATH (repeatable)
 - **`--resource <RESOURCE>`** — Something else the release ships, as KIND[/QUALIFIER]=SOURCE:VALUE where SOURCE is archive (a path inside every archive), asset (a separate release file, by local path), repo (a path at --commit), or exec (a command whose stdout is the file). Kinds: completion/SHELL (or completion/SHELL,SHELL with exec and a {shell} placeholder), man, cli-spec/FORMAT[/BIN], skill/NAME, desktop, icon, app. Example: 'completion/zsh=archive:share/zsh/site-functions/_tool' (repeatable)
 - **`--provenance <PROVENANCE>`** — Provenance URL for every artifact (repeatable, positional order)

--- a/docs/spec/packslip.md
+++ b/docs/spec/packslip.md
@@ -159,6 +159,8 @@ Rules:
   entry a `kind` and one source. See Resources.
 - `notes_url` points at the release notes. `sbom` points at a software
   bill of materials for the release.
+- `extensions` carries what the specification has no field for, keyed by
+  who defines it. See Extensions.
 - `identity` says how the document is signed and by whom, so a consumer
   can check what it pinned against what it received. For `sigstore-oidc`,
   `key_id` is the certificate's subject identity (a workflow URI for CI, an
@@ -232,6 +234,37 @@ An artifact with `bin` is something a command-line package manager
 installs. A release whose resources include `desktop` or `app` is something
 a desktop launcher installs. Many applications are both, and the entries say
 so without a category that would misfile them.
+
+### Extensions
+
+A vendor or a consumer sometimes has something to say that the
+specification has no field for: a package manager's install hints, a
+Homebrew tap, an end-of-life date, a build id. It goes in `extensions`, an
+object that the release predicate, each artifact, each resource, the
+release-list predicate, and each release entry may carry:
+
+```json
+"extensions": {
+  "mise": { "postinstall": "mise reshim" },
+  "example.com": { "build_id": "20260901.3" }
+}
+```
+
+Each key names the party that defines its value: a consumer by its name
+(`mise`, `pacvamp`), a vendor by a domain it controls (`example.com`). The
+value is whatever that party documents. packslip assigns no meaning to
+anything under `extensions` and never will, so nothing put there can
+collide with a field a later revision adds. The signature covers it like
+everything else, and `packslip show` prints it unchanged. A consumer reads
+the keys it defines and ignores the rest.
+
+Everywhere else, a consumer ignores fields it does not know, so a later
+revision of this version can add fields without breaking older consumers.
+A vendor does not use that room for its own data: a field it invents may
+be claimed by a later revision with another meaning, while a key under
+`extensions` never is. Something many vendors put under `extensions` is a
+candidate for a field of its own; when that happens the extension key
+keeps working beside it.
 
 ### Repackager attestation
 
@@ -475,8 +508,9 @@ Action.
   - Executables: `--bin NAME=PATH` when the name on PATH differs from the
     file.
   - URLs: `--url FILENAME=URL` sets one artifact's or asset's URL.
-  - Metadata: `--notes-url`, `--no-sha512`, and `--attested-by repackager`
-    with `--evidence KIND[=DETAIL]`.
+  - Metadata: `--notes-url`, `--sbom`, `--no-sha512`, `--extension
+    NAME=JSON` for a release-level extension, and `--attested-by
+    repackager` with `--evidence KIND[=DETAIL]`.
   - Resources: `--resource KIND[/QUALIFIER]=SOURCE:VALUE`, as in
     `completion/zsh=archive:share/zsh/site-functions/_tool`,
     `completion/bash,zsh,fish=exec:tool completion {shell}`,

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -24,6 +24,7 @@
     <li><a href="#document">The release statement</a></li>
     <li><a href="#fields">Field reference</a></li>
     <li><a href="#resources">Resources</a></li>
+    <li><a href="#extensions">Extensions</a></li>
     <li><a href="#repackager">Repackager attestation</a></li>
     <li><a href="#signing">Signing</a></li>
     <li><a href="#discovery">Discovery</a></li>
@@ -113,6 +114,7 @@
     <li><code>provenance</code> holds URLs of SLSA build provenance statements for that artifact. The packslip proves the manifest; verified provenance proves the build, at whatever SLSA build level its builder establishes.</li>
     <li><code>resources</code> lists what the release ships besides its executables, each entry a <code>kind</code> and one source. See <a href="#resources">Resources</a>.</li>
     <li><code>notes_url</code> points at the release notes. <code>sbom</code> points at a software bill of materials for the release.</li>
+    <li><code>extensions</code> carries what the specification has no field for, keyed by who defines it. See <a href="#extensions">Extensions</a>.</li>
     <li><code>identity</code> says how the document is signed and by whom, so a consumer can check what it pinned against what it received. For <code>sigstore-oidc</code>, <code>key_id</code> is the certificate's subject identity (a workflow URI for CI, an email for a person) and <code>issuer</code> the OIDC issuer. For <code>sigstore-key</code>, <code>key_id</code> is the key id in uppercase hex.</li>
     <li><code>attested_by</code> is <code>vendor</code> (default) or <code>repackager</code>. See below.</li>
   </ul>
@@ -147,6 +149,7 @@
       <tr><td><code>artifacts[].bin[]</code></td><td>array of string or object</td><td><span class="opt">optional</span></td><td>Executables inside the artifact: a path, or <code>{ path, name }</code> when the PATH name differs.</td></tr>
       <tr><td><code>artifacts[].requires</code></td><td>object</td><td><span class="opt">optional</span></td><td><code>os_min</code> and <code>glibc_min</code>.</td></tr>
       <tr><td><code>artifacts[].provenance[]</code></td><td>array of string</td><td><span class="opt">optional</span></td><td>URLs of SLSA build provenance statements for this artifact.</td></tr>
+      <tr><td><code>artifacts[].extensions</code></td><td>object</td><td><span class="opt">optional</span></td><td>Vendor- or consumer-defined data about this artifact. See <a href="#extensions">Extensions</a>.</td></tr>
       <tr><td><code>predicate.resources[]</code></td><td>array of object</td><td><span class="opt">optional</span></td><td>What ships besides the executables. See <a href="#resources">Resources</a>.</td></tr>
       <tr><td><code>resources[].kind</code></td><td>string</td><td><span class="req">required</span></td><td><code>completion</code>, <code>man</code>, <code>cli-spec</code>, <code>skill</code>, <code>desktop</code>, <code>icon</code>, <code>app</code>, or a kind consumers may not know yet.</td></tr>
       <tr><td><code>resources[].archive</code></td><td>string</td><td><span class="opt">one source</span></td><td>Path inside the selected artifact, relative to the archive root.</td></tr>
@@ -159,6 +162,7 @@
       <tr><td><code>resources[].format</code></td><td>string</td><td><span class="opt">cli-spec</span></td><td>The spec format. <code>usage</code> is documented.</td></tr>
       <tr><td><code>resources[].bin</code></td><td>string</td><td><span class="opt">cli-spec</span></td><td>The executable the spec describes, by its <code>bin</code> name.</td></tr>
       <tr><td><code>resources[].name</code></td><td>string</td><td><span class="opt">skill</span></td><td>The skill's name.</td></tr>
+      <tr><td><code>resources[].extensions</code></td><td>object</td><td><span class="opt">optional</span></td><td>Vendor- or consumer-defined data about this resource. See <a href="#extensions">Extensions</a>.</td></tr>
       <tr><td><code>predicate.identity.scheme</code></td><td>string</td><td><span class="req">required</span></td><td><code>sigstore-oidc</code> or <code>sigstore-key</code>.</td></tr>
       <tr><td><code>predicate.identity.key_id</code></td><td>string</td><td><span class="req">required</span></td><td>The certificate identity, or the key id in uppercase hex.</td></tr>
       <tr><td><code>predicate.identity.issuer</code></td><td>string</td><td><span class="opt">optional</span></td><td>The OIDC issuer, for <code>sigstore-oidc</code>.</td></tr>
@@ -166,6 +170,7 @@
       <tr><td><code>predicate.evidence[]</code></td><td>array of object</td><td><span class="opt">optional</span></td><td>What a repackager checked: <code>{ kind, detail }</code>.</td></tr>
       <tr><td><code>predicate.notes_url</code></td><td>string</td><td><span class="opt">optional</span></td><td>URL of the release notes.</td></tr>
       <tr><td><code>predicate.sbom</code></td><td>string</td><td><span class="opt">optional</span></td><td>URL of a software bill of materials for the release.</td></tr>
+      <tr><td><code>predicate.extensions</code></td><td>object</td><td><span class="opt">optional</span></td><td>Vendor- or consumer-defined data about the release, keyed by who defines it. See <a href="#extensions">Extensions</a>.</td></tr>
     </tbody>
   </table>
   </div>
@@ -190,6 +195,15 @@
   </ul>
   <p>For any one need, a consumer takes the first source it can use in the order above: an <code>archive</code> or <code>asset</code> entry, then <code>repo</code>, then one derived from a <code>cli-spec</code>, and only then <code>exec</code>. It ignores kinds and sources it does not know, so a vendor may ship a <code>font</code> or a kind of its own before the specification names it.</p>
   <p>An artifact with <code>bin</code> is something a command-line package manager installs. A release whose resources include <code>desktop</code> or <code>app</code> is something a desktop launcher installs. Many applications are both, and the entries say so without a category that would misfile them.</p>
+
+  <h2 id="extensions">Extensions</h2>
+  <p>A vendor or a consumer sometimes has something to say that the specification has no field for: a package manager's install hints, a Homebrew tap, an end-of-life date, a build id. It goes in <code>extensions</code>, an object that the release predicate, each artifact, each resource, the release-list predicate, and each release entry may carry:</p>
+<pre><code>"extensions": {
+  "mise": { "postinstall": "mise reshim" },
+  "example.com": { "build_id": "20260901.3" }
+}</code></pre>
+  <p>Each key names the party that defines its value: a consumer by its name (<code>mise</code>, <code>pacvamp</code>), a vendor by a domain it controls (<code>example.com</code>). The value is whatever that party documents. packslip assigns no meaning to anything under <code>extensions</code> and never will, so nothing put there can collide with a field a later revision adds. The signature covers it like everything else, and <code>packslip show</code> prints it unchanged. A consumer reads the keys it defines and ignores the rest.</p>
+  <p>Everywhere else, a consumer ignores fields it does not know, so a later revision of this version can add fields without breaking older consumers. A vendor does not use that room for its own data: a field it invents may be claimed by a later revision with another meaning, while a key under <code>extensions</code> never is. Something many vendors put under <code>extensions</code> is a candidate for a field of its own; when that happens the extension key keeps working beside it.</p>
 
   <h2 id="repackager">Repackager attestation</h2>
   <p>A repository or mirror that redistributes a vendor's artifacts, and whose vendor publishes no packslip, may sign one itself with <code>"attested_by": "repackager"</code>. The <code>project</code> still names the vendor's project and the artifacts are still the vendor's files, but <code>identity</code> is the repackager's, and <code>evidence</code> says what it checked before signing:</p>
@@ -283,7 +297,7 @@
         <li>Platforms: <code>path:os/arch[/libc]</code> overrides what the file name implies; <code>path@variant</code> marks a second build of one platform.</li>
         <li>Executables: <code>--bin NAME=PATH</code> when the name on PATH differs from the file.</li>
         <li>URLs: <code>--url FILENAME=URL</code> sets one artifact's or asset's URL.</li>
-        <li>Metadata: <code>--notes-url</code>, <code>--no-sha512</code>, and <code>--attested-by repackager</code> with <code>--evidence KIND[=DETAIL]</code>.</li>
+        <li>Metadata: <code>--notes-url</code>, <code>--sbom</code>, <code>--no-sha512</code>, <code>--extension NAME=JSON</code> for a release-level extension, and <code>--attested-by repackager</code> with <code>--evidence KIND[=DETAIL]</code>.</li>
         <li>Resources: <code>--resource KIND[/QUALIFIER]=SOURCE:VALUE</code>, as in <code>completion/zsh=archive:share/zsh/site-functions/_tool</code>, <code>completion/bash,zsh,fish=exec:tool completion {shell}</code>, <code>man=archive:man/man1/tool.1</code>, <code>cli-spec/usage=exec:tool usage</code>, <code>skill/NAME=repo:skills/tool</code>, <code>skill/NAME=asset:dist/tool-skill.tar.gz</code>, <code>desktop=archive:...</code>, <code>icon=archive:...</code>, or <code>app=archive:Tool.app</code>. A <code>cli-spec</code> describes the sole <code>--bin</code> unless named as <code>cli-spec/usage/NAME</code>. An <code>asset</code> is a local file digested into the subject; a file given as both an artifact and an asset is the asset.</li>
         <li>Signing: <code>--key release.key</code> signs with a key; <code>--no-log</code> skips Rekor.</li>
       </ul>

--- a/packslip.usage.kdl
+++ b/packslip.usage.kdl
@@ -58,6 +58,9 @@ Digests every artifact, infers os/arch/libc/format from file names (override wit
     flag --sbom help="SBOM URL" {
         arg <SBOM>
     }
+    flag --extension help="Release-level extension as NAME=JSON, where NAME is who defines it (a consumer such as mise, or a domain the vendor controls) and JSON is its value. Example: 'example.com={\"build_id\":\"20260901.3\"}' (repeatable)" var=#true {
+        arg <EXTENSION>
+    }
     flag --bin help="Executable inside every archive, as PATH or NAME=PATH (repeatable)" var=#true {
         arg <BIN>
     }

--- a/src/create.rs
+++ b/src/create.rs
@@ -4,9 +4,9 @@
 use std::path::Path;
 
 use crate::model::{
-    Artifact, Attestor, Bin, Digest, Envelope, Evidence, Identity, PREDICATE_TYPE, Predicate,
-    RELEASES_PREDICATE_TYPE, ReleaseList, ReleaseListStatement, ReleaseRef, Requires, Resource,
-    STATEMENT_TYPE, Source, Statement, Subject,
+    Artifact, Attestor, Bin, Digest, Envelope, Evidence, Extensions, Identity, PREDICATE_TYPE,
+    Predicate, RELEASES_PREDICATE_TYPE, ReleaseList, ReleaseListStatement, ReleaseRef, Requires,
+    Resource, STATEMENT_TYPE, Source, Statement, Subject,
 };
 
 /// What `create` needs.
@@ -27,6 +27,8 @@ pub struct Request<'a> {
     pub url_base: Option<&'a str>,
     pub notes_url: Option<&'a str>,
     pub sbom: Option<&'a str>,
+    /// Release-level extensions, keyed by who defines them.
+    pub extensions: Extensions,
     /// Who will sign the document.
     pub identity: Identity,
     pub attested_by: Attestor,
@@ -49,6 +51,7 @@ impl<'a> Request<'a> {
             url_base: None,
             notes_url: None,
             sbom: None,
+            extensions: Extensions::new(),
             identity,
             attested_by: Attestor::Vendor,
             evidence: Vec::new(),
@@ -71,6 +74,8 @@ pub struct ArtifactInput<'a> {
     pub bin: Vec<Bin>,
     pub requires: Option<Requires>,
     pub provenance: Vec<String>,
+    /// Artifact-level extensions, keyed by who defines them.
+    pub extensions: Extensions,
 }
 
 impl<'a> ArtifactInput<'a> {
@@ -85,6 +90,7 @@ impl<'a> ArtifactInput<'a> {
             bin: Vec::new(),
             requires: None,
             provenance: Vec::new(),
+            extensions: Extensions::new(),
         }
     }
 }
@@ -272,6 +278,7 @@ pub fn create(request: &Request<'_>) -> Result<Created, Error> {
             bin,
             requires: input.requires.clone(),
             provenance: input.provenance.clone(),
+            extensions: input.extensions.clone(),
         };
         if let (Some(_), Some(_), Some(_)) = (&artifact.os, &artifact.arch, &artifact.format)
             && let Some(other) = artifacts.iter().find(|a| {
@@ -377,6 +384,7 @@ pub fn create(request: &Request<'_>) -> Result<Created, Error> {
             evidence: request.evidence.clone(),
             notes_url: request.notes_url.map(str::to_string),
             sbom: request.sbom.map(str::to_string),
+            extensions: request.extensions.clone(),
         },
     };
     statement.validate()?;
@@ -479,6 +487,7 @@ pub fn create_release_list(request: &ListRequest<'_>) -> Result<CreatedList, Err
                 .then_some(crate::model::ReleaseStatus::Yanked),
             status_reason: listed.yanked.clone(),
             security: listed.security,
+            extensions: Extensions::new(),
         });
     }
     let statement = Envelope {
@@ -492,6 +501,7 @@ pub fn create_release_list(request: &ListRequest<'_>) -> Result<CreatedList, Err
             sequence: request.sequence,
             identity: request.identity.clone(),
             releases,
+            extensions: Extensions::new(),
         },
     };
     statement.validate()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,8 @@ use packslip::cli::{BinInfo, Version};
 use packslip::create::{ArtifactInput, AssetInput, ListRequest, ListedRelease, Request};
 use packslip::minisign::{PublicKey, SecretKey, key_id_hex};
 use packslip::model::{
-    Attestor, Bin, Evidence, RELEASES_PREDICATE_TYPE, ReleaseListStatement, Resource, Source,
-    Statement,
+    Attestor, Bin, Evidence, Extensions, RELEASES_PREDICATE_TYPE, ReleaseListStatement, Resource,
+    Source, Statement,
 };
 use packslip::sigstore::{self, Policy, Signer, Trust};
 use packslip::verify::Options;
@@ -321,6 +321,12 @@ struct Create {
     /// SBOM URL
     #[usage(long)]
     sbom: Option<String>,
+    /// Release-level extension as NAME=JSON, where NAME is who defines it
+    /// (a consumer such as mise, or a domain the vendor controls) and JSON
+    /// is its value. Example: 'example.com={"build_id":"20260901.3"}'
+    /// (repeatable)
+    #[usage(long)]
+    extension: Vec<String>,
     /// Executable inside every archive, as PATH or NAME=PATH (repeatable)
     #[usage(long)]
     bin: Vec<String>,
@@ -447,6 +453,19 @@ fn parse_evidence(spec: &str) -> Evidence {
     }
 }
 
+/// `NAME=JSON` for `--extension`.
+fn parse_extension(spec: &str) -> Result<(String, serde_json::Value)> {
+    let Some((name, json)) = spec.split_once('=') else {
+        bail!("--extension wants NAME=JSON, got {spec:?}");
+    };
+    if name.is_empty() {
+        bail!("--extension wants a NAME before the =, got {spec:?}");
+    }
+    let value = serde_json::from_str(json)
+        .wrap_err_with(|| format!("--extension {name}: the value is not JSON: {json:?}"))?;
+    Ok((name.to_string(), value))
+}
+
 impl RunWith<BinInfo> for Create {
     type Output = Result<()>;
 
@@ -465,6 +484,13 @@ impl RunWith<BinInfo> for Create {
                 bail!("--url wants FILENAME=URL, got {spec:?}");
             };
             urls.insert(name.to_string(), url.to_string());
+        }
+        let mut extensions = Extensions::new();
+        for spec in &self.extension {
+            let (name, value) = parse_extension(spec)?;
+            if extensions.insert(name.clone(), value).is_some() {
+                bail!("--extension {name:?} is given twice");
+            }
         }
         let bins: Vec<Bin> = self.bin.iter().map(|s| parse_bin(s)).collect();
         let parsed: Vec<ArtifactSpec> = self.artifacts.iter().map(|s| parse_spec(s)).collect();
@@ -487,6 +513,7 @@ impl RunWith<BinInfo> for Create {
                     bin: bins.clone(),
                     requires: None,
                     provenance: self.provenance.get(i).cloned().into_iter().collect(),
+                    extensions: Extensions::new(),
                 }
             })
             .collect();
@@ -535,6 +562,7 @@ impl RunWith<BinInfo> for Create {
             url_base: self.url_base.as_deref(),
             notes_url: self.notes_url.as_deref(),
             sbom: self.sbom.as_deref(),
+            extensions,
             attested_by,
             evidence: self.evidence.iter().map(|s| parse_evidence(s)).collect(),
             sha512: !self.no_sha512,

--- a/src/model.rs
+++ b/src/model.rs
@@ -9,6 +9,13 @@ pub const STATEMENT_TYPE: &str = "https://in-toto.io/Statement/v1";
 pub const PREDICATE_TYPE: &str = "https://packslip.dev/release/v1";
 pub const RELEASES_PREDICATE_TYPE: &str = "https://packslip.dev/releases/v1";
 
+/// What the specification has no field for, keyed by who defines it: a
+/// consumer by its name (`mise`), a vendor by a domain it controls
+/// (`example.com`). packslip assigns no meaning to anything inside, so a
+/// key here never collides with a field a later revision adds. The
+/// signature covers it like everything else.
+pub type Extensions = serde_json::Map<String, serde_json::Value>;
+
 /// An in-toto statement carrying predicate `P`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct Envelope<P> {
@@ -77,6 +84,10 @@ pub struct Predicate {
     pub notes_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sbom: Option<String>,
+    /// Vendor- or consumer-defined data about the release. See
+    /// [`Extensions`].
+    #[serde(default, skip_serializing_if = "Extensions::is_empty")]
+    pub extensions: Extensions,
 }
 
 /// Who signed the claim.
@@ -173,6 +184,10 @@ pub struct Artifact {
     /// URLs of build provenance statements (SLSA) for this artifact.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub provenance: Vec<String>,
+    /// Vendor- or consumer-defined data about this artifact. See
+    /// [`Extensions`].
+    #[serde(default, skip_serializing_if = "Extensions::is_empty")]
+    pub extensions: Extensions,
 }
 
 /// An executable inside an artifact. Serialises as the bare path when the
@@ -291,6 +306,10 @@ pub struct Resource {
     /// a `bin` name. A consumer may decline to run it.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub exec: Vec<String>,
+    /// Vendor- or consumer-defined data about this resource. See
+    /// [`Extensions`].
+    #[serde(default, skip_serializing_if = "Extensions::is_empty")]
+    pub extensions: Extensions,
 }
 
 /// Where a resource comes from, in order of how much a consumer can
@@ -438,6 +457,10 @@ pub struct ReleaseList {
     pub identity: Identity,
     /// In any order; consumers rank by semver precedence.
     pub releases: Vec<ReleaseRef>,
+    /// Vendor- or consumer-defined data about the list. See
+    /// [`Extensions`].
+    #[serde(default, skip_serializing_if = "Extensions::is_empty")]
+    pub extensions: Extensions,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -458,6 +481,10 @@ pub struct ReleaseRef {
     /// may shorten for it.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub security: bool,
+    /// Vendor- or consumer-defined data about this release. See
+    /// [`Extensions`].
+    #[serde(default, skip_serializing_if = "Extensions::is_empty")]
+    pub extensions: Extensions,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -550,6 +577,16 @@ pub enum InvalidDocument {
     OrphanRelease(String),
     #[error("expires_at is not after generated_at")]
     Expiry,
+    #[error("{0} has an extension with an empty key")]
+    ExtensionKey(String),
+}
+
+/// Extension keys name who defines them, so an empty one is a mistake.
+fn check_extensions(owner: &str, extensions: &Extensions) -> Result<(), InvalidDocument> {
+    if extensions.contains_key("") {
+        return Err(InvalidDocument::ExtensionKey(owner.to_string()));
+    }
+    Ok(())
 }
 
 fn check_timestamp(field: &'static str, value: &str) -> Result<jiff::Timestamp, InvalidDocument> {
@@ -628,11 +665,16 @@ impl Statement {
         if p.artifacts.is_empty() {
             return Err(InvalidDocument::NoArtifacts);
         }
+        check_extensions("the release", &p.extensions)?;
         let mut seen = std::collections::BTreeSet::new();
         for artifact in &p.artifacts {
             if !seen.insert(artifact.name.as_str()) {
                 return Err(InvalidDocument::DuplicateArtifact(artifact.name.clone()));
             }
+            check_extensions(
+                &format!("artifact {:?}", artifact.name),
+                &artifact.extensions,
+            )?;
             if !self.subject.iter().any(|s| s.name == artifact.name) {
                 return Err(InvalidDocument::OrphanArtifact(artifact.name.clone()));
             }
@@ -661,6 +703,7 @@ impl Statement {
             if resource.kind.is_empty() {
                 return Err(InvalidDocument::ResourceKind);
             }
+            check_extensions(&format!("resource {label:?}"), &resource.extensions)?;
             let Some(source) = resource.source() else {
                 return Err(InvalidDocument::ResourceSource(label));
             };
@@ -788,12 +831,17 @@ impl ReleaseListStatement {
         if p.releases.is_empty() {
             return Err(InvalidDocument::NoReleases);
         }
+        check_extensions("the release list", &p.extensions)?;
         let mut seen = std::collections::BTreeSet::new();
         for release in &p.releases {
             parse_version(&release.version)?;
             if !seen.insert(release.version.as_str()) {
                 return Err(InvalidDocument::DuplicateRelease(release.version.clone()));
             }
+            check_extensions(
+                &format!("release {:?}", release.version),
+                &release.extensions,
+            )?;
             check_timestamp("published_at", &release.published_at)?;
             if self.digest_of(&release.packslip).is_none() {
                 return Err(InvalidDocument::OrphanRelease(release.version.clone()));
@@ -916,6 +964,7 @@ mod tests {
                     bin: vec![Bin::new("mise/bin/mise")],
                     requires: None,
                     provenance: vec![],
+                    extensions: Extensions::new(),
                 }],
                 resources: vec![],
                 identity: Identity {
@@ -927,6 +976,7 @@ mod tests {
                 evidence: vec![],
                 notes_url: None,
                 sbom: None,
+                extensions: Extensions::new(),
             },
         }
     }
@@ -958,6 +1008,7 @@ mod tests {
                     packslip: "https://dl.example/2026.9.1/packslip.sigstore.json".into(),
                     ..ReleaseRef::default()
                 }],
+                extensions: Extensions::new(),
             },
         }
     }
@@ -1410,6 +1461,66 @@ mod tests {
         }
         assert_eq!(project_host("github.com/jdx/mise"), "github.com");
         assert_eq!(sample().project_host(), "github.com");
+    }
+
+    #[test]
+    fn extensions_round_trip_and_unknown_fields_are_ignored() {
+        let mut doc = serde_json::to_value(sample()).unwrap();
+        doc["predicate"]["extensions"] =
+            serde_json::json!({ "mise": { "postinstall": "mise reshim" } });
+        doc["predicate"]["artifacts"][0]["extensions"] =
+            serde_json::json!({ "example.com": { "build_id": "20260901.3" } });
+        // A field this revision does not define is tolerated, not kept.
+        doc["predicate"]["future_field"] = serde_json::json!(true);
+        let parsed: Statement = serde_json::from_value(doc).unwrap();
+        parsed.validate().unwrap();
+        assert_eq!(
+            parsed.predicate.extensions["mise"]["postinstall"],
+            "mise reshim"
+        );
+        assert_eq!(
+            parsed.predicate.artifacts[0].extensions["example.com"]["build_id"],
+            "20260901.3"
+        );
+        let again: serde_json::Value = serde_json::to_value(&parsed).unwrap();
+        assert_eq!(
+            again["predicate"]["extensions"]["mise"]["postinstall"],
+            "mise reshim"
+        );
+        assert!(again["predicate"].get("future_field").is_none());
+        // Nothing declared, nothing written.
+        let bare = serde_json::to_value(sample()).unwrap();
+        assert!(bare["predicate"].get("extensions").is_none());
+        assert!(
+            bare["predicate"]["artifacts"][0]
+                .get("extensions")
+                .is_none()
+        );
+
+        let mut doc = sample();
+        doc.predicate
+            .extensions
+            .insert("".into(), serde_json::json!(1));
+        assert_eq!(
+            doc.validate(),
+            Err(InvalidDocument::ExtensionKey("the release".into()))
+        );
+        let mut doc = sample();
+        doc.predicate.artifacts[0]
+            .extensions
+            .insert("".into(), serde_json::json!(1));
+        assert!(matches!(
+            doc.validate(),
+            Err(InvalidDocument::ExtensionKey(_))
+        ));
+        let mut list = sample_list();
+        list.predicate.releases[0]
+            .extensions
+            .insert("".into(), serde_json::json!(1));
+        assert!(matches!(
+            list.validate(),
+            Err(InvalidDocument::ExtensionKey(_))
+        ));
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -312,6 +312,14 @@ fn schemas_are_json() {
     assert_eq!(code, 0);
     let schema: serde_json::Value = serde_json::from_str(&out).unwrap();
     assert!(schema["properties"]["predicate"].is_object(), "{out}");
+    let extensions = &schema["$defs"]["Predicate"]["properties"]["extensions"];
+    assert_eq!(extensions["type"], "object", "{extensions}");
+    assert!(
+        extensions
+            .get("additionalProperties")
+            .is_none_or(|p| p != false),
+        "{extensions}"
+    );
     let (code, out, _) = packslip(dir.path(), &["schema", "--releases"]);
     assert_eq!(code, 0);
     let schema: serde_json::Value = serde_json::from_str(&out).unwrap();
@@ -400,6 +408,10 @@ fn variants_urls_evidence_and_monorepo_names() {
             "oxlint_v1.0.0",
             "--published-at",
             "2026-09-01T00:00:00Z",
+            "--extension",
+            r#"example.com={"build_id":"20260901.3"}"#,
+            "--extension",
+            "mise=true",
             "oxlint-linux-x64.tar.gz",
             "oxlint-fips-linux-x64.tar.gz@fips",
             "oxlint-linux-arm64",
@@ -410,6 +422,28 @@ fn variants_urls_evidence_and_monorepo_names() {
         out.contains("wrote dist/packslip.oxlint.sigstore.json (3 artifact(s)"),
         "{out}"
     );
+    for bad in ["nojson", "=1", "mise=not json", "mise={}", "mise=1"] {
+        let args = [
+            "create",
+            "--project",
+            "github.com/oxc-project/oxc/oxlint",
+            "--version",
+            "1.0.0",
+            "--key",
+            "k.key",
+            "--no-log",
+            "--out",
+            "bad",
+            "--extension",
+            "mise={}",
+            "--extension",
+            bad,
+            "oxlint-linux-x64.tar.gz",
+        ];
+        let (code, _, err) = packslip(d, &args);
+        assert_ne!(code, 0, "{bad}");
+        assert!(err.contains("--extension"), "{bad}: {err}");
+    }
     let (code, out, err) = packslip(d, &["show", "dist/packslip.oxlint.sigstore.json"]);
     assert_eq!(code, 0, "{err}");
     let doc: serde_json::Value = serde_json::from_str(&out).unwrap();
@@ -423,6 +457,11 @@ fn variants_urls_evidence_and_monorepo_names() {
     assert!(doc["predicate"].get("prerelease").is_none());
     assert!(doc["predicate"].get("channel").is_none());
     assert_eq!(doc["predicate"]["source"]["tag"], "oxlint_v1.0.0");
+    assert_eq!(
+        doc["predicate"]["extensions"]["example.com"]["build_id"],
+        "20260901.3"
+    );
+    assert_eq!(doc["predicate"]["extensions"]["mise"], true);
     assert_eq!(
         doc["subject"][0]["digest"]["sha512"].as_str().map(str::len),
         Some(128)


### PR DESCRIPTION
## Summary

Leaves room in the spec for vendors and consumers to attach data it has no field for, without stepping on fields a later revision adds.

- The release predicate, each artifact, each resource, the release-list predicate, and each release entry may carry an `extensions` object. Keys name who defines them: a consumer by its name (`mise`, `pacvamp`) or a vendor by a domain it controls (`example.com`). Values are any JSON.
- packslip assigns no meaning to anything under `extensions`, so a key there never collides with a future field. Everywhere else the spec now says consumers ignore fields they do not know, so v1 can grow.
- `packslip create --extension NAME=JSON` sets release-level entries; the action takes them one per line as `extensions`. The value must be JSON, and an empty key is rejected.
- The generated schema declares these objects open (`additionalProperties: true`). The site page, field reference, and README follow the spec text.

Per-artifact and per-resource extensions are in the model and library API; the CLI only sets release-level ones for now.

## Test plan

- [x] `cargo fmt`, `cargo clippy -D warnings`, `cargo test` (new tests: round-trip, unknown fields tolerated, empty-key rejection, CLI flag end to end, schema shape)
- [x] `mise run render`, `usage lint packslip.usage.kdl`, `mise run docs:build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive spec and manifest fields with validation and docs; no changes to signing, verification, or artifact digest logic beyond carrying optional JSON metadata.
> 
> **Overview**
> Introduces **`extensions`** as the sanctioned place for data the packslip spec does not model yet—install hints, build IDs, consumer metadata—without vendors inventing top-level fields that a future spec revision might claim.
> 
> **Spec and docs** define `extensions` on the release predicate, each artifact, each resource, the release-list predicate, and each list entry. Keys name who owns the meaning (consumer name like `mise` or a vendor domain like `example.com`); values are arbitrary JSON. The spec clarifies that packslip never interprets these keys, and that vendors should not stash private data in unknown top-level fields.
> 
> **Implementation** adds an `Extensions` map on the Rust model, wires release-level extensions through `create`, validates non-empty keys, and omits empty maps from serialized output. **`packslip create --extension NAME=JSON`** (repeatable, JSON required, duplicate names rejected) is the only CLI surface for now; per-artifact and per-resource slots exist in the library but stay empty from the CLI. The **GitHub Action** gains an `extensions` input (one `NAME=JSON` per line). README, usage spec, CLI docs, and the site field reference match the canonical spec.
> 
> **Tests** cover round-trip serialization, tolerance of unknown predicate fields, empty-key validation, CLI end-to-end, and open `extensions` objects in the generated JSON schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c0608339e1397b3b1a4be01e9854a2cccbc0378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added repeatable `--extension NAME=JSON` support to `packslip create`.
  - Release manifests can now carry vendor- or consumer-defined extension data for releases, artifacts, resources, and release lists.
  - Added an optional `extensions` input to the GitHub Action.
  - Extension values are validated as JSON, with duplicate or malformed entries rejected.

- **Documentation**
  - Documented extension ownership, structure, validation, signature coverage, and consumer handling across the specification and usage guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->