### PR TITLE
ci: squash generated docs into release commit

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -39,7 +39,7 @@ jobs:
           # built-in token starts no workflow, so CI would never run on
           # the release PR and release.yml would never build the binaries.
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
-      - name: Regenerate CLI documentation in the release PR
+      - name: Squash generated CLI documentation into the release PR
         if: steps.release-plz.outputs.prs_created == 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
@@ -51,8 +51,8 @@ jobs:
           mise run render
           git add packslip.usage.kdl content/cli
           if ! git diff --cached --quiet; then
-            git commit -m "chore: regenerate CLI documentation"
-            git push
+            git commit --amend --no-edit
+            git push --force-with-lease
           fi
 
   # Publishes to crates.io and pushes the tag once a release PR has been


### PR DESCRIPTION
## Summary

- amend regenerated CLI documentation into the release-plz commit
- push the amended release branch with `--force-with-lease`
- avoid standalone generated-documentation commits in release PRs

## Testing

- `mise x actionlint@1.7.7 shellcheck@0.11.0 -- actionlint .github/workflows/release-plz.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to how docs are committed on release PRs; `--force-with-lease` limits accidental overwrites of the release branch.
> 
> **Overview**
> Updates the **release-plz** workflow so regenerated CLI artifacts are folded into the release-plz commit instead of landing as an extra commit on the release PR.
> 
> After `mise run render` and staging `packslip.usage.kdl` and `content/cli`, the step now runs **`git commit --amend --no-edit`** and **`git push --force-with-lease`** rather than a separate `chore: regenerate CLI documentation` commit. The step name is renamed to reflect that behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dfea1b6b900f9e934a85937d3760161674f5c72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->