### PR TITLE
fix(create): androideabi triples are Android too

### DIFF
--- a/src/create.rs
+++ b/src/create.rs
@@ -176,7 +176,12 @@ pub fn infer_platform(name: &str) -> Platform {
             .windows(2)
             .any(|pair| pair[0] == first && pair[1] == second)
     };
-    let os = if follows("linux", "android") || (has("android") && !has("linux")) {
+    let android = |word: &str| word == "android" || word == "androideabi";
+    let os = if tokens
+        .windows(2)
+        .any(|pair| pair[0] == "linux" && android(pair[1]))
+        || (tokens.iter().any(|t| android(t)) && !has("linux"))
+    {
         Some("android")
     } else if follows("apple", "ios")
         || (has("ios") && !has("apple") && !has("darwin") && !has("macos"))
@@ -708,6 +713,10 @@ mod tests {
         assert_eq!(
             infer_platform("tool-android-arm64.tar.gz"),
             (Some("android"), Some("aarch64"), None, Some("tar.gz"))
+        );
+        assert_eq!(
+            infer_platform("tool-armv7-linux-androideabi.tar.gz"),
+            (Some("android"), Some("armv7"), None, Some("tar.gz"))
         );
         assert_eq!(
             infer_platform("tool-ios-arm64.zip"),


### PR DESCRIPTION
Follow-up to #27, from the last Bugbot finding there: Rust's `armv7-linux-androideabi` triple ends in `androideabi`, which the whole-word Android check missed, so such an artifact was recorded as `linux`/`gnu`. Both `android` and `androideabi` now count, under the same rule: after a `linux` token, or when the name has no `linux` token. Test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow heuristic change in filename parsing with a regression test; wrong inference only affects metadata for misnamed files.
> 
> **Overview**
> **`infer_platform`** now classifies Rust-style **`armv7-linux-androideabi`** (and similar) artifact names as **Android**, not generic Linux with **gnu** libc.
> 
> Android detection adds an **`androideabi`** token alongside **`android`**, using the same rules as before: a **`linux`** token immediately before an Android marker, or any Android marker when the name has no **`linux`** token. A unit test covers **`tool-armv7-linux-androideabi.tar.gz`** → **`android`** / **`armv7`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42a6bee12bc660367c3dd9002d364478ae48e4be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved platform detection for Android archive names using the `androideabi` ABI token.
  - Android packages such as `tool-armv7-linux-androideabi.tar.gz` are now classified correctly.

- **Tests**
  - Added coverage for Android filenames containing the `androideabi` token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->