### PR TITLE
spec: an executable's name is the command as typed, never with .exe

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ cannot collide with a field a later revision adds.
 
 `--bin mytool` is looked up inside each archive, so the packslip records
 the true path (`mytool-1.2.3-linux-x64/mytool`), and a bare executable
-such as `mytool-linux-arm64` or `mytool.exe` gets that name on PATH. What
+such as `mytool-linux-arm64` or `mytool.exe` goes on PATH as `mytool`. What
 the flags cannot say per artifact, such as executables at different paths
 in different archives, a `.exe` that is the program rather than an
 installer, host requirements, or an artifact that runs anywhere, goes in

--- a/content/spec.md
+++ b/content/spec.md
@@ -179,7 +179,12 @@ Rules:
   entry is `{ "path": "bin/oxlint-x86_64", "name": "oxlint" }`. Two
   entries may share a path under different names, which is how a vendor
   declares an alias such as `pnpx` for `pnpm`; a consumer may link or
-  copy. Windows entries carry their `.exe`.
+  copy. A name is the command as typed, without `.exe`: a Windows path
+  carries its extension (`bin/tool.exe`) and the consumer puts that file
+  on PATH as `name.exe`. `requires.bin` and a resource's `bin` are
+  written the same way, so names compare without adding or stripping
+  anything. The reference implementation reads an older document that
+  wrote `name` with `.exe` as if it had not.
 - `requires` states what the host must already provide: `os_min` in the
   OS's own terms (`12` for macOS Monterey, `10.0.17763` for Windows),
   `glibc_min` for a `gnu` Linux build, `libs`, the shared libraries the
@@ -255,7 +260,7 @@ Windows installer.
 | `artifacts[].size` | integer | required | File size in bytes. Verified alongside the digest. |
 | `artifacts[].url` | string | optional | Download URL. |
 | `artifacts[].format` | string | optional | Archive, compression, or installer type, or `raw` for a bare executable. |
-| `artifacts[].bin[]` | array of string or object | optional | Executables inside the artifact: a path from the archive root, or `{ path, name }` when the PATH name differs. |
+| `artifacts[].bin[]` | array of string or object | optional | Executables inside the artifact: a path from the archive root, or `{ path, name }` when the PATH name differs. A name is the command as typed, without `.exe`. |
 | `artifacts[].requires` | object | optional | What the host must provide. See Host requirements. |
 | `requires.os_min` | string | optional | Minimum OS version in the OS's own terms. |
 | `requires.glibc_min` | string | optional | Minimum glibc for a `gnu` Linux build. |

--- a/docs/spec/packslip.md
+++ b/docs/spec/packslip.md
@@ -175,7 +175,12 @@ Rules:
   entry is `{ "path": "bin/oxlint-x86_64", "name": "oxlint" }`. Two
   entries may share a path under different names, which is how a vendor
   declares an alias such as `pnpx` for `pnpm`; a consumer may link or
-  copy. Windows entries carry their `.exe`.
+  copy. A name is the command as typed, without `.exe`: a Windows path
+  carries its extension (`bin/tool.exe`) and the consumer puts that file
+  on PATH as `name.exe`. `requires.bin` and a resource's `bin` are
+  written the same way, so names compare without adding or stripping
+  anything. The reference implementation reads an older document that
+  wrote `name` with `.exe` as if it had not.
 - `requires` states what the host must already provide: `os_min` in the
   OS's own terms (`12` for macOS Monterey, `10.0.17763` for Windows),
   `glibc_min` for a `gnu` Linux build, `libs`, the shared libraries the
@@ -251,7 +256,7 @@ Windows installer.
 | `artifacts[].size` | integer | required | File size in bytes. Verified alongside the digest. |
 | `artifacts[].url` | string | optional | Download URL. |
 | `artifacts[].format` | string | optional | Archive, compression, or installer type, or `raw` for a bare executable. |
-| `artifacts[].bin[]` | array of string or object | optional | Executables inside the artifact: a path from the archive root, or `{ path, name }` when the PATH name differs. |
+| `artifacts[].bin[]` | array of string or object | optional | Executables inside the artifact: a path from the archive root, or `{ path, name }` when the PATH name differs. A name is the command as typed, without `.exe`. |
 | `artifacts[].requires` | object | optional | What the host must provide. See Host requirements. |
 | `requires.os_min` | string | optional | Minimum OS version in the OS's own terms. |
 | `requires.glibc_min` | string | optional | Minimum glibc for a `gnu` Linux build. |

--- a/src/create.rs
+++ b/src/create.rs
@@ -81,8 +81,8 @@ pub struct ArtifactInput<'a> {
     /// The format, when it is not what the file name implies: `raw` for
     /// an `.exe` that is the program rather than an installer.
     pub format: Option<String>,
-    /// Executables inside the artifact. On Windows an entry without an
-    /// extension gets `.exe`, on both path and name. For a bare
+    /// Executables inside the artifact. On Windows a path without an
+    /// extension gets `.exe`; the name never has one. For a bare
     /// executable (`raw`, `gz`, `xz`, `zst`, `bz2`), an entry that is a
     /// plain name becomes the artifact's own file under that name.
     pub bin: Vec<Bin>,
@@ -379,15 +379,16 @@ pub fn create(request: &Request<'_>) -> Result<Created, Error> {
                     _ => (b, verified),
                 };
                 if windows {
-                    // The PATH name takes `.exe`. The path takes it only when
-                    // nothing confirmed the file: a path read from the archive
-                    // or the artifact's own name is already exact.
+                    // The path takes `.exe` only when nothing confirmed the
+                    // file: a path read from the archive or the artifact's own
+                    // name is already exact. The name is the command as typed
+                    // and never carries it.
                     let path = if path_is_real {
                         b.path
                     } else {
                         windows_exe(&b.path)
                     };
-                    Bin::named(path, windows_exe(&b.name))
+                    Bin::named(path, b.name)
                 } else {
                     b
                 }
@@ -1056,8 +1057,8 @@ mod tests {
         assert_eq!(arts[0].bin, [Bin::new("tool")]);
         assert_eq!(
             arts[2].bin,
-            [Bin::named("bin/tool.exe", "tool.exe")],
-            "windows gets .exe on path and name"
+            [Bin::named("bin/tool.exe", "tool")],
+            "windows gets .exe on the path, never the name"
         );
         assert_eq!(arts[3].format.as_deref(), Some("raw"));
         assert_eq!(
@@ -1090,15 +1091,9 @@ mod tests {
         assert_eq!(arts[1].format.as_deref(), Some("gz"));
         assert_eq!(arts[1].bin, [Bin::named("tool-linux-x64", "tool")]);
         assert_eq!(arts[2].format.as_deref(), Some("raw"));
-        assert_eq!(
-            arts[2].bin,
-            [Bin::named("tool-windows-x64.exe", "tool.exe")]
-        );
+        assert_eq!(arts[2].bin, [Bin::named("tool-windows-x64.exe", "tool")]);
         assert_eq!(arts[3].format.as_deref(), Some("gz"));
-        assert_eq!(
-            arts[3].bin,
-            [Bin::named("tool-windows-arm64.exe", "tool.exe")]
-        );
+        assert_eq!(arts[3].bin, [Bin::named("tool-windows-arm64.exe", "tool")]);
 
         // A format override and a portable artifact.
         let setup = dir.path().join("tool-x64.exe");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub use manifest::Manifest;
 pub use model::{
     Artifact, Attestor, Bin, Evidence, Host, Identity, Predicate, ReleaseList,
     ReleaseListStatement, ReleaseRef, ReleaseStatus, Requires, Resource, ResourceIdentity,
-    ResourceSource, Scheme, Selection, Source, Statement, Subject, select_artifact,
+    ResourceSource, Scheme, Selection, Source, Statement, Subject, command_name, select_artifact,
     select_resources, tag_version,
 };
 pub use sigstore::{Policy, Signer, Trust};

--- a/src/model.rs
+++ b/src/model.rs
@@ -533,24 +533,41 @@ pub struct Bin {
 }
 
 impl Bin {
+    /// An executable at `path`, put on PATH under its own file name in
+    /// canonical form: `bin/tool.exe` is `tool`.
     pub fn new(path: impl Into<String>) -> Bin {
         let path = path.into();
         Bin {
-            name: file_name(&path).to_string(),
+            name: command_name(file_name(&path)).to_string(),
             path,
         }
     }
 
+    /// An executable at `path` put on PATH under `name`, in canonical
+    /// form.
     pub fn named(path: impl Into<String>, name: impl Into<String>) -> Bin {
+        let name = name.into();
         Bin {
             path: path.into(),
-            name: name.into(),
+            name: command_name(&name).to_string(),
         }
     }
 }
 
 fn file_name(path: &str) -> &str {
     path.rsplit('/').next().unwrap_or(path)
+}
+
+/// A command's name in the form the specification writes it: as typed at
+/// a shell, without `.exe`. `bin[].name`, `requires.bin[].name`, and a
+/// resource's `bin` all use it, so a consumer compares them without
+/// adding or stripping anything; on Windows the file at `bin[].path`
+/// goes on PATH under `name.exe`.
+pub fn command_name(name: &str) -> &str {
+    match name.get(name.len().saturating_sub(4)..) {
+        Some(tail) if tail.eq_ignore_ascii_case(".exe") => &name[..name.len() - 4],
+        _ => name,
+    }
 }
 
 #[derive(Serialize, Deserialize, JsonSchema)]
@@ -564,14 +581,15 @@ impl From<BinRepr> for Bin {
     fn from(repr: BinRepr) -> Bin {
         match repr {
             BinRepr::Path(path) => Bin::new(path),
-            BinRepr::Named { path, name } => Bin { path, name },
+            // A document from before names were canonical reads the same.
+            BinRepr::Named { path, name } => Bin::named(path, name),
         }
     }
 }
 
 impl From<Bin> for BinRepr {
     fn from(bin: Bin) -> BinRepr {
-        if bin.name == file_name(&bin.path) {
+        if bin.name == command_name(file_name(&bin.path)) {
             BinRepr::Path(bin.path)
         } else {
             BinRepr::Named {
@@ -863,11 +881,7 @@ impl Resource {
         // entry naming the Windows form is for the same executable.
         let bin = match self.kind.as_str() {
             "cli-spec" | "skill" | "sbom" => None,
-            _ => self
-                .bin
-                .as_deref()
-                .or(sole_bin)
-                .map(|b| b.strip_suffix(".exe").unwrap_or(b)),
+            _ => self.bin.as_deref().or(sole_bin).map(command_name),
         };
         let id = |parts: Vec<&str>| ResourceIdentity {
             kind: self.kind.clone(),
@@ -1092,6 +1106,10 @@ pub enum InvalidDocument {
     #[error("artifact {0:?} has an executable name containing a slash: {1:?}")]
     BinName(String, String),
     #[error(
+        "artifact {0:?} has an executable name ending in .exe: {1:?}; a name is the command as typed, and the path carries the extension"
+    )]
+    BinNameExe(String, String),
+    #[error(
         "artifact {0:?} requires library {1:?}; a library is named as its loader resolves it, such as libssl.so.3"
     )]
     RequiredLib(String, String),
@@ -1304,6 +1322,12 @@ impl Statement {
                         bin.name.clone(),
                     ));
                 }
+                if command_name(&bin.name) != bin.name {
+                    return Err(InvalidDocument::BinNameExe(
+                        artifact.name.clone(),
+                        bin.name.clone(),
+                    ));
+                }
                 if let Some(expected) = bare
                     && bin.path != expected
                 {
@@ -1334,9 +1358,9 @@ impl Statement {
             .artifacts
             .iter()
             .flat_map(|a| a.bin.iter())
-            .map(|b| b.name.strip_suffix(".exe").unwrap_or(&b.name))
+            .map(|b| command_name(&b.name))
             .collect();
-        let is_bin = |name: &str| bin_names.contains(name.strip_suffix(".exe").unwrap_or(name));
+        let is_bin = |name: &str| bin_names.contains(command_name(name));
         for artifact in &p.artifacts {
             let Some(requires) = &artifact.requires else {
                 continue;
@@ -1513,7 +1537,7 @@ impl Statement {
             .artifacts
             .iter()
             .flat_map(|a| a.bin.iter())
-            .map(|b| b.name.strip_suffix(".exe").unwrap_or(&b.name))
+            .map(|b| command_name(&b.name))
             .collect();
         match names.iter().collect::<Vec<_>>().as_slice() {
             [one] => Some(one),
@@ -1813,6 +1837,33 @@ mod tests {
         .unwrap();
         assert_eq!(named[0], Bin::named("oxlint-x86_64", "oxlint-x86_64"));
         assert_eq!(named[1], Bin::named("bin/oxlint-x86_64", "oxlint"));
+        // Names are the command as typed: never with .exe, whatever the
+        // path or an older document says.
+        assert_eq!(Bin::new("bin/tool.exe").name, "tool");
+        assert_eq!(Bin::new("Tool.EXE").name, "Tool");
+        assert_eq!(Bin::named("tool-windows-x64.exe", "tool.exe").name, "tool");
+        assert_eq!(command_name("tool"), "tool");
+        assert_eq!(command_name(".exe"), "");
+        let exe: Vec<Bin> = serde_json::from_str(
+            r#"["bin/tool.exe", {"path": "tool-x64.exe", "name": "tool.exe"}]"#,
+        )
+        .unwrap();
+        assert_eq!(exe[0], Bin::named("bin/tool.exe", "tool"));
+        assert_eq!(exe[1], Bin::named("tool-x64.exe", "tool"));
+        assert_eq!(
+            serde_json::to_string(&exe).unwrap(),
+            r#"["bin/tool.exe",{"path":"tool-x64.exe","name":"tool"}]"#,
+            "a path whose file name is the command serialises bare"
+        );
+        let mut s = sample();
+        s.predicate.artifacts[0].bin = vec![Bin {
+            path: "tool.exe".into(),
+            name: "tool.exe".into(),
+        }];
+        assert!(matches!(
+            s.validate(),
+            Err(InvalidDocument::BinNameExe(_, _))
+        ));
         assert_eq!(
             serde_json::to_string(&named).unwrap(),
             r#"["oxlint-x86_64",{"path":"bin/oxlint-x86_64","name":"oxlint"}]"#

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -865,7 +865,7 @@ asset = "dist/tool.cdx.json"
     let bare = by_name("tool-1.2.3-windows-arm64.exe");
     assert_eq!(bare["format"], "raw");
     assert_eq!(bare["bin"][0]["path"], "tool-1.2.3-windows-arm64.exe");
-    assert_eq!(bare["bin"][0]["name"], "tool.exe");
+    assert_eq!(bare["bin"][0]["name"], "tool", "the command as typed");
     let res = &doc["predicate"]["resources"];
     assert_eq!(res[0]["kind"], "man");
     assert_eq!(res[0]["os"], "linux");


### PR DESCRIPTION
## Summary

The spec said Windows `bin` entries carry their `.exe`, while `requires.bin` and a resource's `bin` forbid it. Every consumer then strips `.exe` in each place it compares names; mise did it in three.

- `bin[].name` is now the command as typed, without `.exe`. The path keeps its extension and a Windows consumer puts that file on PATH as `name.exe`. All three name fields use one form, so names compare without adjustment.
- `Bin::new`, `Bin::named`, and deserialization canonicalize, so an older document that wrote `name` with `.exe` reads the same; a bare path whose file name is the command still serializes bare. A name built with `.exe` fails validation. `command_name` is exported for consumers.
- `packslip create` stops adding `.exe` to names.

## Test plan
- [x] `cargo test`: `Bin::new("bin/tool.exe").name == "tool"`, old documents read canonically, serialization stays bare, the CLI's Windows fixture records `tool`
- [x] `mise run render`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a spec and manifest-shape change for Windows executable naming; downstream consumers and newly generated packslips will differ from older bundles that stored `tool.exe` as the name, though deserialization still accepts the old form.
> 
> **Overview**
> **Aligns `bin[].name` with how commands are typed** — without `.exe` — while Windows **`path`** values still include `.exe` and installers expose the file on PATH as **`name.exe`**. The same rule applies to **`requires.bin`** and resource **`bin`**, so consumers can compare names without stripping or adding extensions.
> 
> **Reference implementation:** adds exported **`command_name`**, canonicalizes via **`Bin::new` / `Bin::named`** and deserialization (legacy manifests that put `.exe` in **`name`** still read correctly), rejects validated documents whose **`name`** ends in **`.exe`**, and **`packslip create`** no longer appends **`.exe`** to PATH names on Windows (only to paths when needed). Spec/README and tests are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef3fcd3f2bdd0451ff5e827e802d6868a83faf3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->