### PR TITLE
spec: a resource that cannot be fetched is reported; one with the wrong digest fails the install

### DIFF
--- a/content/spec.md
+++ b/content/spec.md
@@ -373,6 +373,15 @@ from a `cli-spec`, and only then `exec`. It ignores kinds and sources it
 does not know, so a vendor may ship a `font` or a kind of its own before
 the specification names it.
 
+A resource is an extra, and the executables are installed with or without
+it. A consumer that cannot fetch one, because the asset or the repository
+file is not there or the network fails, reports that and finishes the
+install without it; a later attempt may fetch it. A resource that arrives
+with a digest other than the one `subject` gives, or a repository file
+that is not what `source.commit` holds, is another matter: that is a
+broken release or a tampered one, and the consumer refuses it as it would
+an artifact.
+
 An artifact with `bin` is something a command-line package manager
 installs. A release whose resources include `desktop` or `app` is something
 a desktop launcher installs. Many applications are both, and the entries say
@@ -809,7 +818,9 @@ which the reference implementation provides as `select_artifact`.
    the entries whose scope fits the selected artifact and the most
    specific of those, then take the most verifiable source offered in the
    order Resources gives; run an `exec` entry only if you have chosen to
-   run vendor code at install time; ignore kinds you do not know.
+   run vendor code at install time; ignore kinds you do not know. A
+   resource you cannot fetch is reported, not fatal; one whose digest is
+   not the one the document signed fails the install.
 
 ## What a verified packslip proves
 

--- a/docs/spec/packslip.md
+++ b/docs/spec/packslip.md
@@ -369,6 +369,15 @@ from a `cli-spec`, and only then `exec`. It ignores kinds and sources it
 does not know, so a vendor may ship a `font` or a kind of its own before
 the specification names it.
 
+A resource is an extra, and the executables are installed with or without
+it. A consumer that cannot fetch one, because the asset or the repository
+file is not there or the network fails, reports that and finishes the
+install without it; a later attempt may fetch it. A resource that arrives
+with a digest other than the one `subject` gives, or a repository file
+that is not what `source.commit` holds, is another matter: that is a
+broken release or a tampered one, and the consumer refuses it as it would
+an artifact.
+
 An artifact with `bin` is something a command-line package manager
 installs. A release whose resources include `desktop` or `app` is something
 a desktop launcher installs. Many applications are both, and the entries say
@@ -805,7 +814,9 @@ which the reference implementation provides as `select_artifact`.
    the entries whose scope fits the selected artifact and the most
    specific of those, then take the most verifiable source offered in the
    order Resources gives; run an `exec` entry only if you have chosen to
-   run vendor code at install time; ignore kinds you do not know.
+   run vendor code at install time; ignore kinds you do not know. A
+   resource you cannot fetch is reported, not fatal; one whose digest is
+   not the one the document signed fails the install.
 
 ## What a verified packslip proves
 


### PR DESCRIPTION
## Summary

The spec said what a consumer does when it declines to run an `exec` resource, but not what it does when an asset or repository file cannot be fetched, or arrives with the wrong digest. mise initially failed the whole install on a 404 for a completion script.

- Resources and consumer rule 8 now say: a resource is an extra, so one that cannot be fetched is reported and the install finishes without it; one whose digest is not what the document signed, or a repository file that is not what `source.commit` holds, fails the install as an artifact would.

Spec text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only clarification of optional resource handling; no runtime or schema changes in this PR.
> 
> **Overview**
> Clarifies **packslip consumer behavior for `resources`**: extras like completions or SBOMs are not required for a successful install.
> 
> The **Resources** section now states that missing assets, missing repo files, or network errors when fetching a resource should be **reported** while the install **completes without** that resource (retries can succeed later). By contrast, a fetched resource whose digest does not match **`subject`**, or a repo file that does not match **`source.commit`**, must **fail the install** like a bad artifact.
> 
> **Consumer rule 8** is updated with the same split: unfetchable resources are non-fatal; wrong digest on a signed resource fails the install.
> 
> Identical wording is added to **`content/spec.md`** and **`docs/spec/packslip.md`** (spec text only; no code changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cbb5bfc67793bd65e6765f0b6c68d5d61990a10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->