### PR TITLE
spec: where SKILL.md sits in each skill source, and when a skill counts as present

### DIFF
--- a/content/spec.md
+++ b/content/spec.md
@@ -359,8 +359,14 @@ Documented kinds:
   would rather not put that dependency on its users' machines ships static
   completions as well.
 - `skill`: an agent skill in the [Agent Skills](https://agentskills.io) format: a directory holding
-  `SKILL.md` and whatever it references, named by `name`. With `exec`, the
-  command prints a single `SKILL.md`.
+  `SKILL.md` and whatever it references, named by `name`. From an
+  `archive` or `repo` source the path is that directory. As an `asset` the
+  skill is an archive of the directory's contents, with `SKILL.md` at the
+  archive root or under one top-level directory, which the consumer
+  strips as it does for an artifact; nothing else is at the root. With
+  `exec`, the command prints a single `SKILL.md`. A consumer counts a
+  skill as present only once `SKILL.md` is in place, so a half-fetched
+  directory never passes for one.
 - `sbom`: a software bill of materials in `format`, `cyclonedx` or `spdx`,
   from an `archive`, `asset`, or `repo` source so that its digest or
   commit covers it. Never from `exec`. A release with one SBOM per

--- a/docs/spec/packslip.md
+++ b/docs/spec/packslip.md
@@ -355,8 +355,14 @@ Documented kinds:
   would rather not put that dependency on its users' machines ships static
   completions as well.
 - `skill`: an agent skill in the [Agent Skills](https://agentskills.io) format: a directory holding
-  `SKILL.md` and whatever it references, named by `name`. With `exec`, the
-  command prints a single `SKILL.md`.
+  `SKILL.md` and whatever it references, named by `name`. From an
+  `archive` or `repo` source the path is that directory. As an `asset` the
+  skill is an archive of the directory's contents, with `SKILL.md` at the
+  archive root or under one top-level directory, which the consumer
+  strips as it does for an artifact; nothing else is at the root. With
+  `exec`, the command prints a single `SKILL.md`. A consumer counts a
+  skill as present only once `SKILL.md` is in place, so a half-fetched
+  directory never passes for one.
 - `sbom`: a software bill of materials in `format`, `cyclonedx` or `spdx`,
   from an `archive`, `asset`, or `repo` source so that its digest or
   commit covers it. Never from `exec`. A release with one SBOM per


### PR DESCRIPTION
## Summary

A skill shipped as an `asset` is an archive, and the spec did not say where `SKILL.md` is inside it, so consumers probed. It also did not say when a skill counts as present, which matters for a fetch cut short.

- The skill kind now says: from `archive` or `repo` the path is the directory; as an `asset` the archive holds the directory's contents with `SKILL.md` at the root or under one top-level directory, stripped as for an artifact; a consumer counts a skill as present only once `SKILL.md` is in place.

Spec text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Spec prose only in two doc files; no schema, tooling, or runtime code changes.
> 
> **Overview**
> **Documentation-only** update to the packslip spec’s `skill` resource kind in `content/spec.md` and the mirrored `docs/spec/packslip.md`.
> 
> The `skill` bullet is expanded so consumers no longer have to guess layout or completion semantics. For **`archive`** and **`repo`** sources, the documented path is the skill directory. For **`asset`**, a skill is an archive of that directory’s contents: **`SKILL.md`** must be at the archive root or under a single top-level directory (stripped like artifact roots), with nothing else at the root. **`exec`** behavior is unchanged (stdout is one **`SKILL.md`**).
> 
> A new rule states that a consumer treats a skill as **present only after `SKILL.md` is on disk**, so a partially fetched directory does not count as installed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00ac003ef2c81b4fa4a2aabd2577d96f0d9a5d4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->