### PR TITLE
spec: what a consumer does with a host requirement the host does not meet

### DIFF
--- a/content/spec.md
+++ b/content/spec.md
@@ -458,11 +458,33 @@ registry. Beside `os_min` and `glibc_min`:
   `extensions`. A required command may not be one the release itself
   provides.
 
-A consumer checks `requires` before installing and reports what is
-missing in its own terms: a distribution package for a soname, a tool it
-can install for a command. It fails on nothing it cannot check: a version
-it cannot read is a warning, not a refusal. Between two artifacts that
-fit the host, it prefers the one whose requirements the host meets.
+A consumer checks `requires` before installing, and what it does with a
+requirement the host does not meet depends on whether the executables can
+run without it:
+
+- A library in `libs` the loader will not find, a `glibc_min` above the
+  host's glibc, or an `os_min` above the host's OS version means the
+  executables will not start. The consumer refuses the install and says
+  what is missing in its own terms: a distribution package for a soname,
+  an OS upgrade. A user may override the refusal for that tool.
+- A command in `bin` that is missing or below its `min` means only the
+  paths that call it fail, and the user may be about to install it. The
+  consumer installs, warns, and names the command and the version it
+  needs, as a tool it can install where it can.
+
+It fails on nothing it cannot check: a version it cannot read, a loader
+it cannot ask, is a warning, not a refusal. Between two artifacts that fit
+the host, it prefers the one whose requirements the host meets.
+
+How to check, on the common hosts: a library by the loader's own search,
+which is the dynamic linker's cache and search path on Linux
+(`ldconfig -p`, `LD_LIBRARY_PATH`), the system library and framework
+directories on macOS, and PATH with the system directory on Windows; a
+command by looking its name up on PATH, with `.exe` on Windows, and
+running it with `--version` to read a version, of which `min` must be a
+prefix by dot-separated components. `glibc_min` compares the same way
+against the host's glibc, and `os_min` against the version the OS
+reports.
 
 That is the boundary. `requires` names what the host must have, by names
 the OS itself resolves. It does not name other projects, versions of
@@ -847,9 +869,11 @@ which the reference implementation provides as `select_artifact`.
    the vendor alone for that project.
 6. Select one artifact as Selecting an artifact says. Refuse to guess
    between two artifacts that tie.
-7. Check `requires` against the host before installing, and report a
-   missing library or command in your own terms. Fail on nothing you
-   cannot check. Between two artifacts that tie, prefer the one whose
+7. Check `requires` against the host before installing, as Host
+   requirements says: refuse when a library, glibc, or OS version means
+   the executables cannot start, warn when a command is missing or too
+   old, and report either in your own terms. Fail on nothing you cannot
+   check. Between two artifacts that tie, prefer the one whose
    requirements the host meets.
 8. For each thing the resources describe, as Resources defines one, keep
    the entries whose scope fits the selected artifact and the most

--- a/docs/spec/packslip.md
+++ b/docs/spec/packslip.md
@@ -454,11 +454,33 @@ registry. Beside `os_min` and `glibc_min`:
   `extensions`. A required command may not be one the release itself
   provides.
 
-A consumer checks `requires` before installing and reports what is
-missing in its own terms: a distribution package for a soname, a tool it
-can install for a command. It fails on nothing it cannot check: a version
-it cannot read is a warning, not a refusal. Between two artifacts that
-fit the host, it prefers the one whose requirements the host meets.
+A consumer checks `requires` before installing, and what it does with a
+requirement the host does not meet depends on whether the executables can
+run without it:
+
+- A library in `libs` the loader will not find, a `glibc_min` above the
+  host's glibc, or an `os_min` above the host's OS version means the
+  executables will not start. The consumer refuses the install and says
+  what is missing in its own terms: a distribution package for a soname,
+  an OS upgrade. A user may override the refusal for that tool.
+- A command in `bin` that is missing or below its `min` means only the
+  paths that call it fail, and the user may be about to install it. The
+  consumer installs, warns, and names the command and the version it
+  needs, as a tool it can install where it can.
+
+It fails on nothing it cannot check: a version it cannot read, a loader
+it cannot ask, is a warning, not a refusal. Between two artifacts that fit
+the host, it prefers the one whose requirements the host meets.
+
+How to check, on the common hosts: a library by the loader's own search,
+which is the dynamic linker's cache and search path on Linux
+(`ldconfig -p`, `LD_LIBRARY_PATH`), the system library and framework
+directories on macOS, and PATH with the system directory on Windows; a
+command by looking its name up on PATH, with `.exe` on Windows, and
+running it with `--version` to read a version, of which `min` must be a
+prefix by dot-separated components. `glibc_min` compares the same way
+against the host's glibc, and `os_min` against the version the OS
+reports.
 
 That is the boundary. `requires` names what the host must have, by names
 the OS itself resolves. It does not name other projects, versions of
@@ -843,9 +865,11 @@ which the reference implementation provides as `select_artifact`.
    the vendor alone for that project.
 6. Select one artifact as Selecting an artifact says. Refuse to guess
    between two artifacts that tie.
-7. Check `requires` against the host before installing, and report a
-   missing library or command in your own terms. Fail on nothing you
-   cannot check. Between two artifacts that tie, prefer the one whose
+7. Check `requires` against the host before installing, as Host
+   requirements says: refuse when a library, glibc, or OS version means
+   the executables cannot start, warn when a command is missing or too
+   old, and report either in your own terms. Fail on nothing you cannot
+   check. Between two artifacts that tie, prefer the one whose
    requirements the host meets.
 8. For each thing the resources describe, as Resources defines one, keep
    the entries whose scope fits the selected artifact and the most


### PR DESCRIPTION
## Summary

#32 added `requires.libs` and `requires.bin` and said a consumer "reports what is missing", without saying whether that is a refusal or a warning, or how to check.

- Host requirements now distinguishes what stops the executables from starting (a library the loader will not find, `glibc_min`, `os_min`), which the consumer refuses with a per-tool override, from a command in `bin` that is missing or too old, which it warns about and installs anyway. It still fails on nothing it cannot check.
- A paragraph says how to check on the common hosts: the loader's own search for libraries, PATH plus `--version` for commands, prefix comparison on dot-separated components.
- Consumer rule 7 matches.

Spec text only; mise implements none of this yet and this is what it will implement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only spec clarification with no code or schema changes in this PR.
> 
> **Overview**
> Clarifies **Host requirements** so consumers no longer treat every unmet `requires` entry the same way.
> 
> **Refuse install** (with a per-tool user override) when missing `libs`, `glibc_min`, or `os_min` would stop the executables from starting; messaging stays in the consumer’s own terms (dist packages, OS upgrade). **Install with a warning** when a `requires.bin` command is missing or below `min`, since only code paths that invoke it break and the user may install that tool next.
> 
> Adds normative guidance for **how to check** on Linux, macOS, and Windows (loader search, PATH/`--version`, prefix version compares). **Consumer rule 7** now points at this section and matches the refuse-vs-warn split. The same edits land in `content/spec.md` and `docs/spec/packslip.md`; no runtime behavior changes in this repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ede88f58e7604b7f2df6e4ef63cae472c74b9bbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->