### PR TITLE
spec: list_url and github_list_path give where a release list lives

### DIFF
--- a/content/spec.md
+++ b/content/spec.md
@@ -660,6 +660,11 @@ host. For `mise.jdx.dev` that is
 which github.com does not serve, and the next section says what a
 consumer does there. A forge that does serve it needs nothing else.
 
+The reference implementation gives the URL as `list_url`, for a project's
+own list and for one another publisher keeps for it (see Lists from other
+publishers), and the path of a GitHub repository's supplementary list as
+`github_list_path`.
+
 A project on its own domain must publish the list: a consumer that finds
 none refuses the project rather than guessing at URLs. `packslip releases`
 produces the list from local copies of the released bundles; the JSON
@@ -706,7 +711,8 @@ and its packslip cannot be deleted.
 A list need not come from the vendor. A registry, a mirror, or a scanning
 service publishes lists under its own host, one per vendor project it
 covers, at the well-known path with the vendor's project name:
-`https://registry.example/.well-known/packslip/github.com/jdx/mise.json`.
+`https://registry.example/.well-known/packslip/github.com/jdx/mise.json`,
+which `list_url` gives for a publisher that is not the project's host.
 A consumer configures which such hosts it trusts, one setting per host.
 
 Each entry points at a packslip and pins its digest. The packslip may be

--- a/docs/spec/packslip.md
+++ b/docs/spec/packslip.md
@@ -656,6 +656,11 @@ host. For `mise.jdx.dev` that is
 which github.com does not serve, and the next section says what a
 consumer does there. A forge that does serve it needs nothing else.
 
+The reference implementation gives the URL as `list_url`, for a project's
+own list and for one another publisher keeps for it (see Lists from other
+publishers), and the path of a GitHub repository's supplementary list as
+`github_list_path`.
+
 A project on its own domain must publish the list: a consumer that finds
 none refuses the project rather than guessing at URLs. `packslip releases`
 produces the list from local copies of the released bundles; the JSON
@@ -702,7 +707,8 @@ and its packslip cannot be deleted.
 A list need not come from the vendor. A registry, a mirror, or a scanning
 service publishes lists under its own host, one per vendor project it
 covers, at the well-known path with the vendor's project name:
-`https://registry.example/.well-known/packslip/github.com/jdx/mise.json`.
+`https://registry.example/.well-known/packslip/github.com/jdx/mise.json`,
+which `list_url` gives for a publisher that is not the project's host.
 A consumer configures which such hosts it trusts, one setting per host.
 
 Each entry points at a packslip and pins its digest. The packslip may be

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@ pub use manifest::Manifest;
 pub use model::{
     Artifact, Attestor, Bin, Evidence, Host, Identity, Predicate, ReleaseList,
     ReleaseListStatement, ReleaseRef, ReleaseStatus, Requires, Resource, ResourceIdentity,
-    ResourceSource, Scheme, Selection, Source, Statement, Subject, command_name, select_artifact,
-    select_resources, tag_version,
+    ResourceSource, Scheme, Selection, Source, Statement, Subject, command_name, github_list_path,
+    list_url, select_artifact, select_resources, tag_version,
 };
 pub use sigstore::{Policy, Signer, Trust};
 pub use verify::{Options, Verified, VerifiedList, verify, verify_release_list};

--- a/src/model.rs
+++ b/src/model.rs
@@ -1673,6 +1673,42 @@ pub fn repository_subpath(project: &str) -> Option<&str> {
     rest.strip_prefix('/').filter(|s| !s.is_empty())
 }
 
+/// Where a publisher keeps its release list for a project, as Discovery
+/// says. A project's own list, when `publisher` is the project's host,
+/// is at `https://<host>/.well-known/packslip/<path>.json`, or
+/// `https://<host>/.well-known/packslip.json` when the name is a bare
+/// host. Another publisher's list for the project, a registry's or a
+/// mirror's, is under that publisher's host with the whole project name
+/// as the path: `https://<publisher>/.well-known/packslip/<project>.json`.
+pub fn list_url(publisher: &str, project: &str) -> String {
+    let host = project_host(project);
+    let path = if publisher == host {
+        project
+            .get(host.len()..)
+            .unwrap_or_default()
+            .trim_start_matches('/')
+    } else {
+        project
+    };
+    if path.is_empty() {
+        format!("https://{publisher}/.well-known/packslip.json")
+    } else {
+        format!("https://{publisher}/.well-known/packslip/{path}.json")
+    }
+}
+
+/// Where a GitHub repository keeps its supplementary signed list, as a
+/// path on its default branch: `.well-known/packslip.json`, or
+/// `.well-known/packslip/<tool>.json` for a monorepo tool. `None` for a
+/// project that is not a GitHub repository.
+pub fn github_list_path(project: &str) -> Option<String> {
+    repository(project)?;
+    Some(match repository_subpath(project) {
+        Some(tool) => format!(".well-known/packslip/{tool}.json"),
+        None => ".well-known/packslip.json".to_string(),
+    })
+}
+
 /// A project name is a lowercase DNS host, optionally followed by path
 /// segments: `github.com/jdx/mise`, `mise.jdx.dev`. No scheme, no empty
 /// or dot segments, no trailing slash, and the host has at least one dot.
@@ -2770,6 +2806,39 @@ mod tests {
             [&s.predicate.resources[1]],
             "the scoped entry that names the sole executable hides the unnamed one"
         );
+    }
+
+    #[test]
+    fn list_urls_follow_discovery() {
+        assert_eq!(
+            list_url("mise.jdx.dev", "mise.jdx.dev"),
+            "https://mise.jdx.dev/.well-known/packslip.json"
+        );
+        assert_eq!(
+            list_url("jdx.dev", "jdx.dev/mise"),
+            "https://jdx.dev/.well-known/packslip/mise.json"
+        );
+        assert_eq!(
+            list_url("github.com", "github.com/jdx/mise"),
+            "https://github.com/.well-known/packslip/jdx/mise.json"
+        );
+        assert_eq!(
+            list_url("registry.example", "github.com/jdx/mise"),
+            "https://registry.example/.well-known/packslip/github.com/jdx/mise.json"
+        );
+        assert_eq!(
+            list_url("registry.example", "mise.jdx.dev"),
+            "https://registry.example/.well-known/packslip/mise.jdx.dev.json"
+        );
+        assert_eq!(
+            github_list_path("github.com/jdx/mise").as_deref(),
+            Some(".well-known/packslip.json")
+        );
+        assert_eq!(
+            github_list_path("github.com/oxc-project/oxc/oxlint").as_deref(),
+            Some(".well-known/packslip/oxlint.json")
+        );
+        assert_eq!(github_list_path("mise.jdx.dev"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Discovery defines three places a release list can live: the project's own well-known URL, another publisher's well-known URL for the project, and a GitHub repository's supplementary file. Each consumer was rebuilding the URLs by hand, and mise's coming trusted-hosts setting needs the second one.

- `list_url(publisher, project)` gives the first two, depending on whether the publisher is the project's host; `github_list_path(project)` gives the third. The spec names both beside the rules they implement.

## Test plan
- [x] `cargo test`: bare host, host with path, github.com, a registry's list for a GitHub project and for a domain project, monorepo tool paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds documented URL helpers and spec text only; no changes to verification or signing behavior.
> 
> **Overview**
> Centralizes **Discovery** release-list location rules so consumers (e.g. mise trusted-host settings) do not hand-build well-known URLs.
> 
> The crate adds **`list_url(publisher, project)`** for a project’s own signed list when `publisher` is the project host, and for a registry/mirror list under another host when it is not. **`github_list_path(project)`** returns the default-branch path for a GitHub repo’s supplementary list (`.well-known/packslip.json` or a monorepo tool segment). Both are re-exported from the public API.
> 
> The spec docs in `content/spec.md` and `docs/spec/packslip.md` name these helpers next to the discovery rules, including that third-party publisher URLs come from `list_url`. Unit tests cover bare host, path projects, `github.com`, registry URLs, and monorepo tool paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b355c907ce334bf89b2ea069d99a98713e9325ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->