### PR TITLE
feat(resources): scope a resource to one release artifact

### DIFF
--- a/content/spec.md
+++ b/content/spec.md
@@ -269,6 +269,7 @@ Windows installer.
 | `artifacts[].provenance[]` | array of string | optional | URLs of SLSA build provenance statements for this artifact. |
 | `predicate.resources[]` | array of object | optional | What ships besides the executables. See Resources. |
 | `resources[].kind` | string | required | `completion`, `man`, `cli-spec`, `skill`, `sbom`, `desktop`, `icon`, `app`, or a kind consumers may not know yet. |
+| `resources[].artifact` | string | optional | Exact artifact filename. Limits this resource to that artifact and outranks platform-only scope. |
 | `resources[].os`, `arch`, `libc` | string | optional | Limit the entry to artifacts of that platform, when layouts differ. |
 | `resources[].archive` | string | one source | Path inside the selected artifact, from the archive root. |
 | `resources[].asset` | string | one source | Name of a separate release file, listed in `subject` with its digest. |
@@ -317,7 +318,16 @@ prefers them in this order:
 Layouts differ by platform more often than by file, so an entry may carry
 `os`, `arch`, or `libc` to say which artifacts it describes; an entry
 without them describes every artifact. A resource applies to the selected
-artifact when each field it carries equals the artifact's.
+artifact when each field it carries equals the artifact's. An entry may
+also name `artifact`, the exact filename in `artifacts`, when archives for
+the same platform have different layouts or a resource belongs to one
+variant. That artifact must exist and match any platform scope on the
+entry. An artifact-specific entry outranks every platform-only entry for
+the same resource; among equally scoped entries the platform specificity
+and source ordering below apply. For example, a man page inside
+`tool-linux-x64.tar.xz` can name that artifact without claiming the bare
+`tool-linux-x64` executable holds a man page. A TOML manifest spells this
+as `artifact = "tool-linux-x64.tar.xz"` inside `[[resource]]`.
 
 Entries compete only with entries for the same thing. Two entries are for
 the same thing when they share a `kind` and an identity: `bin` and

--- a/docs/spec/packslip.md
+++ b/docs/spec/packslip.md
@@ -265,6 +265,7 @@ Windows installer.
 | `artifacts[].provenance[]` | array of string | optional | URLs of SLSA build provenance statements for this artifact. |
 | `predicate.resources[]` | array of object | optional | What ships besides the executables. See Resources. |
 | `resources[].kind` | string | required | `completion`, `man`, `cli-spec`, `skill`, `sbom`, `desktop`, `icon`, `app`, or a kind consumers may not know yet. |
+| `resources[].artifact` | string | optional | Exact artifact filename. Limits this resource to that artifact and outranks platform-only scope. |
 | `resources[].os`, `arch`, `libc` | string | optional | Limit the entry to artifacts of that platform, when layouts differ. |
 | `resources[].archive` | string | one source | Path inside the selected artifact, from the archive root. |
 | `resources[].asset` | string | one source | Name of a separate release file, listed in `subject` with its digest. |
@@ -313,7 +314,16 @@ prefers them in this order:
 Layouts differ by platform more often than by file, so an entry may carry
 `os`, `arch`, or `libc` to say which artifacts it describes; an entry
 without them describes every artifact. A resource applies to the selected
-artifact when each field it carries equals the artifact's.
+artifact when each field it carries equals the artifact's. An entry may
+also name `artifact`, the exact filename in `artifacts`, when archives for
+the same platform have different layouts or a resource belongs to one
+variant. That artifact must exist and match any platform scope on the
+entry. An artifact-specific entry outranks every platform-only entry for
+the same resource; among equally scoped entries the platform specificity
+and source ordering below apply. For example, a man page inside
+`tool-linux-x64.tar.xz` can name that artifact without claiming the bare
+`tool-linux-x64` executable holds a man page. A TOML manifest spells this
+as `artifact = "tool-linux-x64.tar.xz"` inside `[[resource]]`.
 
 Entries compete only with entries for the same thing. Two entries are for
 the same thing when they share a `kind` and an identity: `bin` and

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -140,6 +140,8 @@ impl ArtifactSpec {
 #[serde(deny_unknown_fields)]
 pub struct ResourceSpec {
     pub kind: String,
+    /// Exact release artifact filename, not a local path.
+    pub artifact: Option<String>,
     /// Limit the entry to artifacts of this platform.
     pub os: Option<String>,
     pub arch: Option<String>,
@@ -178,6 +180,7 @@ impl ResourceSpec {
         };
         let resource = Resource {
             kind: self.kind.clone(),
+            artifact: self.artifact.clone(),
             os: self.os.clone(),
             arch: self.arch.clone(),
             libc: self.libc.clone(),

--- a/src/model.rs
+++ b/src/model.rs
@@ -285,17 +285,22 @@ pub fn normalize_version(text: &str) -> Option<String> {
 }
 
 /// Whether a resource applies to an artifact: each of the resource's
-/// `os`, `arch`, and `libc` is absent or equal to the artifact's. A
+/// `os`, `arch`, and `libc` is absent or equal to the artifact's, and
+/// an `artifact` selector names it. A
 /// consumer choosing among entries for the same thing takes the one
 /// naming the most of those fields; [`select_resources`] does that.
 pub fn resource_fits(resource: &Resource, artifact: &Artifact) -> bool {
-    [
-        (&resource.os, &artifact.os),
-        (&resource.arch, &artifact.arch),
-        (&resource.libc, &artifact.libc),
-    ]
-    .into_iter()
-    .all(|(scope, value)| scope.is_none() || scope == value)
+    resource
+        .artifact
+        .as_ref()
+        .is_none_or(|name| name == &artifact.name)
+        && [
+            (&resource.os, &artifact.os),
+            (&resource.arch, &artifact.arch),
+            (&resource.libc, &artifact.libc),
+        ]
+        .into_iter()
+        .all(|(scope, value)| scope.is_none() || scope == value)
 }
 
 /// The resources to use with one artifact, as the specification's
@@ -320,10 +325,13 @@ fn select_among<'a>(
     identities_of: impl Fn(&Resource) -> Vec<ResourceIdentity>,
 ) -> Vec<&'a Resource> {
     let specificity = |r: &Resource| {
-        [&r.os, &r.arch, &r.libc]
-            .iter()
-            .filter(|f| f.is_some())
-            .count()
+        (
+            r.artifact.is_some(),
+            [&r.os, &r.arch, &r.libc]
+                .iter()
+                .filter(|f| f.is_some())
+                .count(),
+        )
     };
     let identities: Vec<Vec<ResourceIdentity>> = resources.iter().map(&identities_of).collect();
     let mut keep = vec![false; resources.len()];
@@ -343,7 +351,7 @@ fn select_among<'a>(
                 .iter()
                 .map(|&i| specificity(&resources[i]))
                 .max()
-                .unwrap_or(0);
+                .unwrap_or_default();
             for i in fitting {
                 if specificity(&resources[i]) == best {
                     keep[i] = true;
@@ -730,6 +738,9 @@ fn valid_min_version(min: &str) -> bool {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct Resource {
     pub kind: String,
+    /// Exact artifact name. More specific than any platform-only scope.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact: Option<String>,
     /// Limits the entry to artifacts of this `os`, when layouts differ by
     /// platform. Absent means any artifact. See [`resource_fits`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1149,6 +1160,8 @@ pub enum InvalidDocument {
     NoArtifacts,
     #[error("a resource has an empty kind")]
     ResourceKind,
+    #[error("resource {0:?} names artifact {1:?}, which is absent or outside its platform scope")]
+    ResourceArtifact(String, String),
     #[error("resource {0:?} must have exactly one of archive, asset, repo, exec")]
     ResourceSource(String),
     #[error("resource {0:?}: {1} path must be relative with no empty or .. segments")]
@@ -1423,6 +1436,11 @@ impl Statement {
                 return Err(InvalidDocument::ResourceKind);
             }
             check_extensions(&format!("resource {label:?}"), &resource.extensions)?;
+            if let Some(name) = &resource.artifact
+                && !p.artifacts.iter().any(|a| resource_fits(resource, a))
+            {
+                return Err(InvalidDocument::ResourceArtifact(label, name.clone()));
+            }
             let Some(source) = resource.source() else {
                 return Err(InvalidDocument::ResourceSource(label));
             };
@@ -2734,6 +2752,62 @@ mod tests {
             !resource_fits(&windows, &artifacts[4]),
             "a portable artifact is not a Windows one"
         );
+    }
+
+    #[test]
+    fn resource_artifact_scope_distinguishes_formats_and_variants() {
+        let mut s = sample();
+        let target = s.predicate.artifacts[0].clone();
+        let fallback = Resource {
+            os: target.os.clone(),
+            arch: target.arch.clone(),
+            libc: target.libc.clone(),
+            shell: Some("zsh".into()),
+            archive: Some("share/_mise".into()),
+            ..Resource::new("completion")
+        };
+        let exact = Resource {
+            artifact: Some(target.name.clone()),
+            os: None,
+            arch: None,
+            libc: None,
+            archive: Some("other-layout/_mise".into()),
+            ..fallback.clone()
+        };
+        s.predicate.resources = vec![fallback.clone(), exact.clone()];
+        s.validate().unwrap();
+        assert_eq!(
+            select_resources(&s, &target),
+            vec![&s.predicate.resources[1]]
+        );
+        for (name, format, variant) in [
+            ("mise.zip", "zip", None),
+            ("mise-fips.tar.xz", "tar.xz", Some("fips")),
+            ("mise", "raw", None),
+        ] {
+            let other = Artifact {
+                name: name.into(),
+                format: Some(format.into()),
+                variant: variant.map(Into::into),
+                ..target.clone()
+            };
+            assert!(!resource_fits(&exact, &other));
+            assert_eq!(
+                select_resources(&s, &other),
+                vec![&s.predicate.resources[0]]
+            );
+        }
+        s.predicate.resources[1].artifact = Some("missing.tar.xz".into());
+        assert!(matches!(
+            s.validate(),
+            Err(InvalidDocument::ResourceArtifact(_, _))
+        ));
+        s.predicate.resources[1].artifact = Some(target.name);
+        s.predicate.resources[1].os = Some("windows".into());
+        assert!(matches!(
+            s.validate(),
+            Err(InvalidDocument::ResourceArtifact(_, _))
+        ));
     }
 
     #[test]

--- a/static/schema/release-v1.json
+++ b/static/schema/release-v1.json
@@ -344,6 +344,13 @@
             "null"
           ]
         },
+        "artifact": {
+          "description": "Exact artifact name. More specific than any platform-only scope.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "asset": {
           "description": "The name of a separate release file, listed in `subject` with its\ndigest.",
           "type": [


### PR DESCRIPTION
Resources scoped only by OS/architecture/libc also apply to other archives, raw binaries, and variants for that platform. Add an optional exact artifact filename, validate that it names an artifact within the declared platform scope, and rank it ahead of platform-only entries.

Includes TOML manifest support, regenerated schema/spec, and regression coverage for archive alternatives, variants, raw binaries, missing targets, and contradictory scope.

Validation: all 57 Rust tests passed; clippy with warnings denied; generated docs and production documentation build passed.
