### PR TITLE
feat(releases): support a vendor-selected latest version

### DIFF
--- a/content/cli/releases.md
+++ b/content/cli/releases.md
@@ -10,6 +10,7 @@ For a project on its own domain: lists released packslips with their digests so 
 ## Flags
 - **`--project <PROJECT>`** — The project's name, which every listed packslip must carry
 - **`--sequence <SEQUENCE>`** — Increases with every list published
+- **`--latest <LATEST>`** — Recommend this exact listed version for unconstrained latest requests
 - **`--valid-for <VALID_FOR>`** — How long the list stays current: 30d, 12h, 2w
 
   **Default:** `30d`

--- a/content/spec.md
+++ b/content/spec.md
@@ -633,6 +633,7 @@ A signed list is a bundle of the same shape as a packslip, with the
     "generated_at": "2026-09-01T12:00:00Z",
     "expires_at": "2026-10-01T12:00:00Z",
     "sequence": 42,
+    "latest": "2026.9.1",
     "identity": { "scheme": "sigstore-key", "key_id": "5A0A0B8B9C6D7E1F" },
     "releases": [
       { "version": "2026.9.1", "tag": "v2026.9.1", "published_at": "2026-09-01T12:00:00Z",
@@ -659,7 +660,13 @@ spells it, and `published_at`, copied from the packslip. It may carry
 someone other than the vendor, `evidence` saying what the publisher
 checked. A consumer never selects a yanked release, warns when it holds
 one, and may shorten its minimum release age for a security release.
-Nothing else about a release lives on the list: its version says the rest.
+The optional list-level `latest` is the vendor's recommended default, as
+an exact semver string matching an entry's `version`, including any build
+metadata. It is not a tag, range, or per-release flag. A pointer to a
+version absent from the list makes the list invalid. Its target may be
+yanked or otherwise ineligible; that does not invalidate the list, and
+Latest below defines the fallback. `packslip releases --latest 2.8.4`
+sets it. Omitting the option omits the pointer.
 
 The list is published at
 
@@ -717,8 +724,9 @@ It is signed by the same identity the packslips are, and it is
 supplementary: a version it names is taken as it says, yanked or flagged,
 and pinned to the packslip digest it gives; a version it omits still comes
 from the endpoint. So a vendor touches it only to withdraw a release, to
-mark a security fix, or to list a release whose tag names no version, and
-a vendor that never needs those never writes it. Withdrawing a release
+mark a security fix, recommend a default with `latest`, or list a release
+whose tag names no version, and a vendor that never needs those never
+writes it. Withdrawing a release
 this way works on a repository with immutable releases, where the release
 and its packslip cannot be deleted.
 
@@ -774,11 +782,11 @@ One required scheme is what lets everything about a release follow from
 its signed version string, with no flag anywhere that could disagree with
 it:
 
-- Order is semver precedence. "Latest" is the highest eligible version, so
-  a backport such as 20.19.1 published after 22.0.0 never masquerades as
-  the newest release, and range constraints (`^1.2`) have meaning. Build
-  metadata takes no part, as semver says. The order of the release list,
-  GitHub's or the vendor's, is not consulted.
+- Order is semver precedence. A backport such as 20.19.1 published after
+  22.0.0 still ranks below it, and range constraints (`^1.2`) have meaning.
+  Build metadata takes no part, as semver says. The order of the release
+  list, GitHub's or the vendor's, is not consulted. A vendor may separately
+  recommend a default for `latest`, as Latest defines.
 - A prerelease is a version with a prerelease part: `1.2.0-rc.1` is one,
   `1.2.0` is not. Consumers skip prereleases unless asked for them.
   Promoting a release candidate means cutting the final version, not
@@ -805,10 +813,58 @@ and on a GitHub repository with immutable releases it can never be
 replaced, while GitHub's own prerelease flag stays editable after
 publishing. A flag in the document would end up either frozen or
 contradicted. So the packslip says what shipped, the version says how to
-treat it, and the one thing that stays mutable, withdrawing a release, is
-the release list's job. An earlier draft let a vendor declare list order
+treat it, and mutable withdrawal and default recommendations belong in
+discovery metadata. An earlier draft let a vendor declare list order
 instead of semver; it went, because the prerelease and channel fields it
 then needed had no honest home.
+
+### Latest
+
+An unconstrained `latest` request (including a consumer's default install
+request) asks for the vendor's recommended eligible release. Ordering
+and recommendation are separate: a vendor may publish `3.0.0` while
+recommending `2.8.4`. Exact versions, version prefixes, ranges, and channel
+requests continue to use their matching rules and semver precedence;
+the default pointer does not reorder them.
+
+Consumers choose a recommendation in this order:
+
+1. Use `latest` from the vendor's accepted signed release list, if present.
+   On GitHub this includes the supplementary list. The list must pass its
+   normal signature, identity, expiry, and sequence checks first.
+2. For a GitHub project without a signed `latest`, use the release returned
+   by GitHub's [latest release endpoint](https://docs.github.com/en/rest/releases/releases#get-the-latest-release).
+   Resolve its tag through the normal discovery rules, including a signed
+   list entry's `tag` mapping. It must belong to the requested project;
+   a repository-wide pointer to another tool is not a recommendation for
+   this one. This is an unsigned discovery hint, not proof of authenticity
+   or a sequence-protected recommendation.
+3. Elsewhere, without a signed pointer there is no recommendation.
+
+Select the recommendation only if it passes the same checks as any other
+candidate: verified release signature and identity, manifest version and
+digest consistency, no vendor yank, prerelease policy, minimum release
+age, configured stamping policy, and artifact/host eligibility. A pointer
+never admits a release a consumer would otherwise refuse. Pointers on
+third-party stamping lists do not replace the vendor's recommendation;
+those lists determine which candidates are admitted.
+
+If there is no recommendation, or its target is absent from discovery or
+excluded by eligibility policy, select the highest eligible semver from
+the normal candidate set. An ineligible signed pointer falls directly
+back to semver selection, not to GitHub's pointer. Report when a declared
+recommendation is skipped and why; if no eligible release exists, fail.
+For example, if `latest` is `2.8.4` but it is yanked or too young, `3.0.0`
+may be selected if it is eligible. Vendors who must exclude `3.0.0` must
+withdraw it or use an admission policy, rather than relying on `latest`.
+
+Fallback does not turn verification failures into missing metadata.
+An invalid, expired, rolled-back, or unexpectedly missing signed list
+remains an error; a candidate with a bad signature or inconsistent digest
+or version remains an error. A GitHub latest endpoint response indicating
+no latest release supplies no pointer; other fetch errors remain errors.
+Changing or removing a signed recommendation requires publishing a new
+list with an increased sequence, without replacing any release manifest.
 
 ### Spelling a version
 

--- a/docs/spec/packslip.md
+++ b/docs/spec/packslip.md
@@ -629,6 +629,7 @@ A signed list is a bundle of the same shape as a packslip, with the
     "generated_at": "2026-09-01T12:00:00Z",
     "expires_at": "2026-10-01T12:00:00Z",
     "sequence": 42,
+    "latest": "2026.9.1",
     "identity": { "scheme": "sigstore-key", "key_id": "5A0A0B8B9C6D7E1F" },
     "releases": [
       { "version": "2026.9.1", "tag": "v2026.9.1", "published_at": "2026-09-01T12:00:00Z",
@@ -655,7 +656,13 @@ spells it, and `published_at`, copied from the packslip. It may carry
 someone other than the vendor, `evidence` saying what the publisher
 checked. A consumer never selects a yanked release, warns when it holds
 one, and may shorten its minimum release age for a security release.
-Nothing else about a release lives on the list: its version says the rest.
+The optional list-level `latest` is the vendor's recommended default, as
+an exact semver string matching an entry's `version`, including any build
+metadata. It is not a tag, range, or per-release flag. A pointer to a
+version absent from the list makes the list invalid. Its target may be
+yanked or otherwise ineligible; that does not invalidate the list, and
+Latest below defines the fallback. `packslip releases --latest 2.8.4`
+sets it. Omitting the option omits the pointer.
 
 The list is published at
 
@@ -713,8 +720,9 @@ It is signed by the same identity the packslips are, and it is
 supplementary: a version it names is taken as it says, yanked or flagged,
 and pinned to the packslip digest it gives; a version it omits still comes
 from the endpoint. So a vendor touches it only to withdraw a release, to
-mark a security fix, or to list a release whose tag names no version, and
-a vendor that never needs those never writes it. Withdrawing a release
+mark a security fix, recommend a default with `latest`, or list a release
+whose tag names no version, and a vendor that never needs those never
+writes it. Withdrawing a release
 this way works on a repository with immutable releases, where the release
 and its packslip cannot be deleted.
 
@@ -770,11 +778,11 @@ One required scheme is what lets everything about a release follow from
 its signed version string, with no flag anywhere that could disagree with
 it:
 
-- Order is semver precedence. "Latest" is the highest eligible version, so
-  a backport such as 20.19.1 published after 22.0.0 never masquerades as
-  the newest release, and range constraints (`^1.2`) have meaning. Build
-  metadata takes no part, as semver says. The order of the release list,
-  GitHub's or the vendor's, is not consulted.
+- Order is semver precedence. A backport such as 20.19.1 published after
+  22.0.0 still ranks below it, and range constraints (`^1.2`) have meaning.
+  Build metadata takes no part, as semver says. The order of the release
+  list, GitHub's or the vendor's, is not consulted. A vendor may separately
+  recommend a default for `latest`, as Latest defines.
 - A prerelease is a version with a prerelease part: `1.2.0-rc.1` is one,
   `1.2.0` is not. Consumers skip prereleases unless asked for them.
   Promoting a release candidate means cutting the final version, not
@@ -801,10 +809,58 @@ and on a GitHub repository with immutable releases it can never be
 replaced, while GitHub's own prerelease flag stays editable after
 publishing. A flag in the document would end up either frozen or
 contradicted. So the packslip says what shipped, the version says how to
-treat it, and the one thing that stays mutable, withdrawing a release, is
-the release list's job. An earlier draft let a vendor declare list order
+treat it, and mutable withdrawal and default recommendations belong in
+discovery metadata. An earlier draft let a vendor declare list order
 instead of semver; it went, because the prerelease and channel fields it
 then needed had no honest home.
+
+### Latest
+
+An unconstrained `latest` request (including a consumer's default install
+request) asks for the vendor's recommended eligible release. Ordering
+and recommendation are separate: a vendor may publish `3.0.0` while
+recommending `2.8.4`. Exact versions, version prefixes, ranges, and channel
+requests continue to use their matching rules and semver precedence;
+the default pointer does not reorder them.
+
+Consumers choose a recommendation in this order:
+
+1. Use `latest` from the vendor's accepted signed release list, if present.
+   On GitHub this includes the supplementary list. The list must pass its
+   normal signature, identity, expiry, and sequence checks first.
+2. For a GitHub project without a signed `latest`, use the release returned
+   by GitHub's [latest release endpoint](https://docs.github.com/en/rest/releases/releases#get-the-latest-release).
+   Resolve its tag through the normal discovery rules, including a signed
+   list entry's `tag` mapping. It must belong to the requested project;
+   a repository-wide pointer to another tool is not a recommendation for
+   this one. This is an unsigned discovery hint, not proof of authenticity
+   or a sequence-protected recommendation.
+3. Elsewhere, without a signed pointer there is no recommendation.
+
+Select the recommendation only if it passes the same checks as any other
+candidate: verified release signature and identity, manifest version and
+digest consistency, no vendor yank, prerelease policy, minimum release
+age, configured stamping policy, and artifact/host eligibility. A pointer
+never admits a release a consumer would otherwise refuse. Pointers on
+third-party stamping lists do not replace the vendor's recommendation;
+those lists determine which candidates are admitted.
+
+If there is no recommendation, or its target is absent from discovery or
+excluded by eligibility policy, select the highest eligible semver from
+the normal candidate set. An ineligible signed pointer falls directly
+back to semver selection, not to GitHub's pointer. Report when a declared
+recommendation is skipped and why; if no eligible release exists, fail.
+For example, if `latest` is `2.8.4` but it is yanked or too young, `3.0.0`
+may be selected if it is eligible. Vendors who must exclude `3.0.0` must
+withdraw it or use an admission policy, rather than relying on `latest`.
+
+Fallback does not turn verification failures into missing metadata.
+An invalid, expired, rolled-back, or unexpectedly missing signed list
+remains an error; a candidate with a bad signature or inconsistent digest
+or version remains an error. A GitHub latest endpoint response indicating
+no latest release supplies no pointer; other fetch errors remain errors.
+Changing or removing a signed recommendation requires publishing a new
+list with an increased sequence, without replacing any release manifest.
 
 ### Spelling a version
 

--- a/packslip.usage.kdl
+++ b/packslip.usage.kdl
@@ -109,6 +109,9 @@ For a project on its own domain: lists released packslips with their digests so 
     flag --sequence help="Increases with every list published" required=#true {
         arg <SEQUENCE>
     }
+    flag --latest help="Recommend this exact listed version for unconstrained latest requests" {
+        arg <LATEST>
+    }
     flag --valid-for help="How long the list stays current: 30d, 12h, 2w" default="30d" {
         arg <VALID_FOR>
     }

--- a/src/create.rs
+++ b/src/create.rs
@@ -585,6 +585,8 @@ pub struct ListRequest<'a> {
     /// How long the list stays current.
     pub valid_for: std::time::Duration,
     pub sequence: u64,
+    /// Exact listed version recommended for unconstrained latest requests.
+    pub latest: Option<&'a str>,
     pub releases: Vec<ListedRelease<'a>>,
     pub identity: Identity,
 }
@@ -674,6 +676,7 @@ pub fn create_release_list(request: &ListRequest<'_>) -> Result<CreatedList, Err
             generated_at: generated.to_string(),
             expires_at: expires.to_string(),
             sequence: request.sequence,
+            latest: request.latest.map(str::to_owned),
             identity: request.identity.clone(),
             releases,
             extensions: Extensions::new(),
@@ -1345,6 +1348,7 @@ mod tests {
             generated_at: Some("2026-09-01T01:00:00Z"),
             valid_for: std::time::Duration::from_secs(30 * 86_400),
             sequence: 3,
+            latest: Some("1.0.0"),
             releases: vec![ListedRelease {
                 url: "https://dl.example.com/1.0.0/packslip.sigstore.json",
                 bundle_path: &bundle_path,
@@ -1356,6 +1360,7 @@ mod tests {
         })
         .unwrap();
         assert_eq!(list.statement.predicate.expires_at, "2026-10-01T01:00:00Z");
+        assert_eq!(list.statement.predicate.latest.as_deref(), Some("1.0.0"));
         let entry = &list.statement.predicate.releases[0];
         assert_eq!(entry.version, "1.0.0");
         assert_eq!(entry.tag.as_deref(), Some("v1.0.0"));
@@ -1378,6 +1383,10 @@ mod tests {
             crate::verify::verify_release_list(&list_bundle, &Trust::Key(&public), options)
                 .unwrap();
         assert_eq!(verified_list.list.predicate.sequence, 3);
+        assert_eq!(
+            verified_list.list.predicate.latest.as_deref(),
+            Some("1.0.0")
+        );
         assert!(
             verified_list
                 .list
@@ -1389,6 +1398,7 @@ mod tests {
             generated_at: None,
             valid_for: std::time::Duration::from_secs(60),
             sequence: 4,
+            latest: None,
             releases: vec![
                 ListedRelease {
                     url: "https://x/a.sigstore.json",
@@ -1414,6 +1424,7 @@ mod tests {
             generated_at: None,
             valid_for: std::time::Duration::from_secs(60),
             sequence: 1,
+            latest: None,
             releases: vec![ListedRelease {
                 url: "https://x/packslip.sigstore.json",
                 bundle_path: &bundle_path,

--- a/src/main.rs
+++ b/src/main.rs
@@ -892,6 +892,9 @@ struct Releases {
     /// Increases with every list published
     #[usage(long)]
     sequence: u64,
+    /// Recommend this exact listed version for unconstrained latest requests
+    #[usage(long)]
+    latest: Option<String>,
     /// How long the list stays current: 30d, 12h, 2w
     #[usage(long, default = "30d")]
     valid_for: String,
@@ -980,6 +983,7 @@ impl RunWith<BinInfo> for Releases {
             generated_at: self.generated_at.as_deref(),
             valid_for: parse_duration(&self.valid_for)?,
             sequence: self.sequence,
+            latest: self.latest.as_deref(),
             releases,
             identity: signer.identity(),
         })?;

--- a/src/model.rs
+++ b/src/model.rs
@@ -1027,6 +1027,11 @@ pub struct ReleaseList {
     /// than it has seen.
     pub sequence: u64,
     pub identity: Identity,
+    /// The vendor's recommended default: an exact version in `releases`.
+    /// Consumers still apply all eligibility checks before selecting it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(regex(pattern = SEMVER_PATTERN))]
+    pub latest: Option<String>,
     /// In any order; consumers rank by semver precedence.
     pub releases: Vec<ReleaseRef>,
     /// Vendor- or consumer-defined data about the list. See
@@ -1208,6 +1213,8 @@ pub enum InvalidDocument {
     NoReleases,
     #[error("release {0:?} appears more than once")]
     DuplicateRelease(String),
+    #[error("latest {0:?} does not name a version in the release list")]
+    UnknownLatest(String),
     #[error("release {0:?} has no subject carrying its packslip digest")]
     OrphanRelease(String),
     #[error("expires_at is not after generated_at")]
@@ -1641,6 +1648,12 @@ impl ReleaseListStatement {
                 return Err(InvalidDocument::OrphanRelease(release.version.clone()));
             }
         }
+        if let Some(latest) = &p.latest {
+            parse_version(latest)?;
+            if !seen.contains(latest.as_str()) {
+                return Err(InvalidDocument::UnknownLatest(latest.clone()));
+            }
+        }
         Ok(())
     }
 
@@ -1826,6 +1839,7 @@ mod tests {
                 generated_at: "2026-09-01T12:00:00Z".into(),
                 expires_at: "2026-10-01T12:00:00Z".into(),
                 sequence: 7,
+                latest: None,
                 identity: Identity {
                     scheme: Scheme::SigstoreKey,
                     key_id: "5A0A0B8B9C6D7E1F".into(),
@@ -1839,6 +1853,37 @@ mod tests {
                 }],
                 extensions: Extensions::new(),
             },
+        }
+    }
+
+    #[test]
+    fn latest_is_an_optional_exact_listed_version() {
+        let mut list = sample_list();
+        let json = serde_json::to_value(&list).unwrap();
+        assert!(json["predicate"].get("latest").is_none());
+        let old: ReleaseListStatement = serde_json::from_value(json).unwrap();
+        old.validate().unwrap();
+        assert_eq!(old.predicate.latest, None);
+
+        list.predicate.latest = Some("2026.9.1".into());
+        list.validate().unwrap();
+        // Eligibility is consumer policy: withdrawing the recommended release
+        // does not invalidate the list or erase the withdrawal.
+        list.predicate.releases[0].status = Some(ReleaseStatus::Yanked);
+        list.validate().unwrap();
+        let roundtrip: ReleaseListStatement =
+            serde_json::from_slice(&list.canonical_bytes()).unwrap();
+        assert_eq!(roundtrip, list);
+        for invalid in ["latest", "v2026.9.1", "2026.9", ""] {
+            list.predicate.latest = Some(invalid.into());
+            assert!(list.validate().is_err());
+        }
+        for missing in ["3.0.0", "2026.9.1+other"] {
+            list.predicate.latest = Some(missing.into());
+            assert_eq!(
+                list.validate(),
+                Err(InvalidDocument::UnknownLatest(missing.into()))
+            );
         }
     }
 

--- a/static/schema/releases-v1.json
+++ b/static/schema/releases-v1.json
@@ -83,6 +83,14 @@
         "identity": {
           "$ref": "#/$defs/Identity"
         },
+        "latest": {
+          "description": "The vendor's recommended default: an exact version in `releases`.\nConsumers still apply all eligibility checks before selecting it.",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "project": {
           "type": "string"
         },

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -628,6 +628,8 @@ fn variants_urls_evidence_and_monorepo_names() {
             "releases",
             "--project",
             "packages.example.com/tool",
+            "--latest",
+            "2.0.0",
             "--sequence",
             "1",
             "--release",
@@ -660,6 +662,7 @@ fn variants_urls_evidence_and_monorepo_names() {
     let (code, out, _) = packslip(d, &["show", "list.sigstore.json"]);
     assert_eq!(code, 0);
     let list: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(list["predicate"]["latest"], "2.0.0");
     assert_eq!(list["predicate"]["releases"][0]["status"], "yanked");
     assert_eq!(
         list["predicate"]["releases"][0]["status_reason"],


### PR DESCRIPTION
Semver ordering currently forces `latest` to select the highest eligible version, preventing a vendor from publishing 3.0.0 while recommending 2.8.4. Add an optional signed release-list `latest` pointer and `packslip releases --latest VERSION`, validating that it exactly names a listed semver version.

The specification defines signed vendor pointer → GitHub latest pointer when no signed pointer exists → highest eligible semver. An ineligible recommendation falls directly back to semver, with an explanation. Signature, digest, identity, list freshness/continuity, yanks, age, stamping, and host eligibility still apply; verification errors are not fallback conditions. Ranges and channels keep semver ordering, and stamping lists do not override vendor recommendations.

Includes regenerated schema, CLI reference, and specification page. Tests cover old lists without the field, exact membership (including build metadata), invalid spellings, yanked targets, and signed library/CLI round trips.

Validation: all 58 Rust tests passed; clippy with warnings denied; documentation generation and production build; diff whitespace check. Consumer resolution is specified here; mise still needs to implement this new policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release-list semantics and documents consumer selection behavior that downstream tools must implement consistently; in-repo changes are mostly validation and list authoring.
> 
> **Overview**
> Adds an optional list-level **`latest`** field so vendors can recommend a specific semver for unconstrained “install latest” requests, separate from semver ordering (e.g. ship `3.0.0` but recommend `2.8.4`).
> 
> **Publishing:** `packslip releases --latest VERSION` writes the pointer into signed release lists; the field is omitted when unset. Validation requires an exact semver that matches a **`releases[]`** entry (unknown versions fail with **`UnknownLatest`**); pointing at a yanked release still validates—the spec defines consumer fallback.
> 
> **Spec:** New **Latest** section documents priority (signed list → GitHub latest API → none), eligibility checks, semver fallback, and that verification/list errors are not softened by fallback.
> 
> **Schema/docs/tests:** `releases-v1` JSON schema, CLI usage, and mirrored spec docs updated; unit and CLI tests cover round-trip and invalid pointers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cb4796c8fb4f7802641b2fe7f6c55e34fcc12dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->