### PR TITLE
fix(release): version the action and CLI in lockstep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: release
 
 # Runs when release-plz pushes a version tag after its release PR is
-# merged (see RELEASING.md). `v1` is the action's major tag, moved by
-# this workflow; it must not start a release of its own.
+# merged (see RELEASING.md). Moving major tags (v0, v1, ...) must not
+# start releases of their own.
 on:
   push:
     tags: ["v[0-9]+.[0-9]+.[0-9]+"]
@@ -14,7 +14,32 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      major-tag: ${{ steps.version.outputs.major-tag }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Check the shared action and CLI version
+        id: version
+        shell: python
+        run: |
+          import os
+          import re
+          import tomllib
+
+          with open("Cargo.toml", "rb") as manifest:
+              version = tomllib.load(manifest)["package"]["version"]
+          if not re.fullmatch(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)", version):
+              raise SystemExit(f"unsupported release version: {version}")
+          tag = os.environ["GITHUB_REF_NAME"]
+          if tag != f"v{version}":
+              raise SystemExit(f"release tag {tag} does not match Cargo.toml v{version}")
+          with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+              output.write(f"major-tag=v{version.split('.')[0]}\n")
+
   build:
+    needs: version
     strategy:
       fail-fast: false
       matrix:
@@ -78,7 +103,7 @@ jobs:
           if-no-files-found: error
 
   release:
-    needs: build
+    needs: [version, build]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -159,20 +184,22 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release edit "$GITHUB_REF_NAME" --draft=false
-      # `uses: jdx/packslip@v1` follows the latest release. A push made with
+      # The action follows releases of the same CLI major, only after the
+      # binaries are public. A push made with
       # the built-in token starts no workflow, so this cannot recurse.
-      - name: Move the v1 action tag
+      - name: Move the shared major action tag
         env:
+          MAJOR_TAG: ${{ needs.version.outputs.major-tag }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           for attempt in 1 2 3; do
-            git tag -f v1 "$GITHUB_SHA"
-            if git push -f origin v1; then
+            git tag -f "$MAJOR_TAG" "$GITHUB_SHA"
+            if git push -f origin "refs/tags/$MAJOR_TAG"; then
               break
             fi
-            git fetch origin "refs/tags/v1:refs/tags/v1" -f || true
+            git fetch origin "refs/tags/$MAJOR_TAG:refs/tags/$MAJOR_TAG" -f || true
             [ "$attempt" -lt 3 ] || exit 1
           done

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ homepage = "https://packslip.dev"
 authors = ["Jeff Dickey <@jdx>"]
 keywords = ["sigstore", "in-toto", "release", "supply-chain", "minisign"]
 categories = ["command-line-utilities", "cryptography"]
-exclude = ["content/", "data/", "layouts/", "static/", "hugo.toml", ".github/", "action.yml", "CHANGELOG.md", "RELEASING.md", "cliff.toml", "release-plz.toml"]
+# Keep action.yml in the package so action-only changes trigger a shared release.
+exclude = ["content/", "data/", "layouts/", "static/", "hugo.toml", ".github/", "CHANGELOG.md", "RELEASING.md", "cliff.toml", "release-plz.toml"]
 
 [[bin]]
 name = "packslip"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ permissions:
   attestations: write   # attest build provenance for the artifacts
 
 steps:
-  - uses: jdx/packslip@v1
+  - uses: jdx/packslip@v0
     with:
       artifacts: dist/*
       bin: mytool
@@ -49,6 +49,11 @@ links the provenance from it, and uploads `packslip.sigstore.json` to the
 release. There is no key to create or store. Consumers verify against the
 repository name: a packslip for `github.com/owner/repo` must be signed by
 a workflow of that repository.
+
+The action and CLI share a version: `@v0` follows CLI 0.x releases, and
+`@v0.2.0` pins both to 0.2.0. By default, the action installs the CLI
+version from its own commit's `Cargo.toml`. `packslip-version` explicitly
+overrides that selection when needed.
 
 ## The binary
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,8 +16,9 @@ Nothing is released by pushing to `main`.
 4. The tag starts `release.yml`, which builds the five binaries, attests
    them, creates a draft GitHub release, rewrites its generated notes with
    [Communiqué](https://github.com/jdx/communique), publishes the release's
-   own packslip, publishes the draft, and moves the `v1` tag so
-   `uses: jdx/packslip@v1` follows.
+   own packslip, publishes the draft, and moves the matching major tag
+   (`v0` for a `0.x.y` release, `v1` for `1.x.y`, and so on). Before
+   building, it checks that the tag matches `Cargo.toml`.
 
 Communiqué's project context and tone instructions live in
 `communique.toml`. Its version is declared in `mise.toml` and resolved in
@@ -25,7 +26,15 @@ Communiqué's project context and tone instructions live in
 fails, the release keeps GitHub's generated notes and continues.
 
 The action reads its default packslip version from its own `Cargo.toml`,
-so the release PR bumps it too; no other file needs editing.
+so the release PR bumps it too; no other file needs editing. `action.yml`
+is included in the Cargo package so release-plz detects action-only changes
+and proposes a shared release for them too. Use conventional commits such
+as `fix(action): ...` or `feat(action): ...`; breaking action changes are
+breaking changes to the shared version.
+
+An exact action tag such as `@v0.2.0` uses CLI 0.2.0 by default. The
+`packslip-version` input is an explicit escape hatch, not a separate action
+version. Moving major tags advance only after the CLI assets are published.
 
 ## One-time setup
 
@@ -48,6 +57,9 @@ so the release PR bumps it too; no other file needs editing.
 
 ## Tags
 
-- `vX.Y.Z`: one per release, pushed by release-plz.
-- `v1`: the action's major tag, moved by `release.yml` after each release.
+- `vX.Y.Z`: one shared action and CLI tag per release, pushed by release-plz.
+- `vX`: the matching major tag, moved by `release.yml` after publication.
   It is excluded from `release.yml`'s trigger and from the changelog.
+- The former `v1` alias for 0.x releases is no longer advanced by 0.x
+  releases. Consumers of that alias should switch to `v0` or an exact
+  version; `v1` is reserved for CLI 1.x releases.

--- a/cliff.toml
+++ b/cliff.toml
@@ -79,7 +79,7 @@ commit_parsers = [
 ]
 protect_breaking_commits = false
 filter_commits = false
-# Only version tags; `v1` is the action's moving major tag.
+# Only full version tags; exclude the action's moving major tags.
 tag_pattern = '^v\d+\.\d+\.\d+$'
 topo_order = false
 sort_commits = "oldest"

--- a/content/spec.md
+++ b/content/spec.md
@@ -1002,7 +1002,7 @@ The reference implementation is the `packslip` crate and binary in
 [jdx/packslip](https://github.com/jdx/packslip), also usable as a GitHub
 Action.
 
-- In a release job: `uses: jdx/packslip@v1` with `artifacts: dist/*`
+- In a release job: `uses: jdx/packslip@v0` with `artifacts: dist/*`
   attests build provenance for the artifacts, signs the packslip
   keylessly, links the provenance from it, verifies the result, and
   uploads the bundle to the release. `bin` names the executables,

--- a/docs/spec/packslip.md
+++ b/docs/spec/packslip.md
@@ -998,7 +998,7 @@ The reference implementation is the `packslip` crate and binary in
 [jdx/packslip](https://github.com/jdx/packslip), also usable as a GitHub
 Action.
 
-- In a release job: `uses: jdx/packslip@v1` with `artifacts: dist/*`
+- In a release job: `uses: jdx/packslip@v0` with `artifacts: dist/*`
   attests build provenance for the artifacts, signs the packslip
   keylessly, links the provenance from it, verifies the result, and
   uploads the bundle to the release. `bin` names the executables,


### PR DESCRIPTION
The action currently advances `v1` even for CLI 0.x releases, and action-only changes are excluded from release-plz’s package change detection.

Keep the action and CLI on the same version: reject release tags that disagree with `Cargo.toml`, advance the matching major action tag only after publishing the CLI assets, and include `action.yml` in the Cargo package so action-only changes can trigger a shared release. Update examples and release documentation to use `v0` for CLI 0.x; the former `v1` alias will no longer advance on 0.x releases. The explicit `packslip-version` override remains available.

Validation: exercised the workflow version check against seven matching, mismatched, and unsupported version/tag pairs; parsed the workflow YAML; confirmed `cargo package --list --allow-dirty --offline` includes `action.yml`; and ran `git diff --check`. The release workflow has not been executed against remote tags.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release tagging and CI gates (tag/Cargo.toml mismatch aborts the workflow), which affects consumers still on `@v1` for 0.x; runtime code paths are mostly documentation and packaging.
> 
> **Overview**
> Aligns the GitHub Action with the CLI so **0.x releases advance `@v0`**, not a hardcoded **`@v1`**, and action-only changes can trigger releases.
> 
> The **release workflow** adds a **`version` job** that fails if the pushed tag does not match **`Cargo.toml`**, then moves the matching **major tag** (`v0`, `v1`, …) only **after** binaries are published—replacing the old always-**`v1`** step.
> 
> **`action.yml` is no longer excluded** from the Cargo package so release-plz can detect action-only changes and bump the shared version. Docs and examples switch from **`jdx/packslip@v1`** to **`@v0`** for the current 0.x line and document that the former **`v1` alias on 0.x** will stop being updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 226f49ee4e087624b8bf104dad4dfd91d8292784. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->