### PR TITLE
docs(spec): define resource fallback tie order

### DIFF
--- a/content/spec.md
+++ b/content/spec.md
@@ -343,6 +343,14 @@ another name leaves that skill in place, and a zsh completion for one
 platform says nothing about the bash one. The reference implementation
 provides this as `select_resources`.
 
+Within the same identity, specificity, and source type, entries are tried
+in their order in `resources`. This final tie-breaker is an ordered list
+of alternatives: the first usable entry wins, and a consumer stops fetching
+or running lower-priority entries once that need is satisfied. For example,
+two equally scoped `repo` entries for one skill try the first directory,
+then the second only if the first is unavailable. A verification failure
+still refuses the release; it is not a reason to try an alternative.
+
 Documented kinds:
 
 - `completion`: a shell completion script. With a static source, `shell`
@@ -390,7 +398,9 @@ Documented kinds:
 
 For any one need, a consumer takes the first source it can use in the
 order above: an `archive` or `asset` entry, then `repo`, then one derived
-from a `cli-spec`, and only then `exec`. It ignores kinds and sources it
+from a `cli-spec`, and only then `exec`. Static `cli-spec` sources use the
+same `archive`, `asset`, `repo` ordering, with document order breaking ties
+within each source type. It ignores kinds and sources it
 does not know, so a vendor may ship a `font` or a kind of its own before
 the specification names it.
 

--- a/docs/spec/packslip.md
+++ b/docs/spec/packslip.md
@@ -339,6 +339,14 @@ another name leaves that skill in place, and a zsh completion for one
 platform says nothing about the bash one. The reference implementation
 provides this as `select_resources`.
 
+Within the same identity, specificity, and source type, entries are tried
+in their order in `resources`. This final tie-breaker is an ordered list
+of alternatives: the first usable entry wins, and a consumer stops fetching
+or running lower-priority entries once that need is satisfied. For example,
+two equally scoped `repo` entries for one skill try the first directory,
+then the second only if the first is unavailable. A verification failure
+still refuses the release; it is not a reason to try an alternative.
+
 Documented kinds:
 
 - `completion`: a shell completion script. With a static source, `shell`
@@ -386,7 +394,9 @@ Documented kinds:
 
 For any one need, a consumer takes the first source it can use in the
 order above: an `archive` or `asset` entry, then `repo`, then one derived
-from a `cli-spec`, and only then `exec`. It ignores kinds and sources it
+from a `cli-spec`, and only then `exec`. Static `cli-spec` sources use the
+same `archive`, `asset`, `repo` ordering, with document order breaking ties
+within each source type. It ignores kinds and sources it
 does not know, so a vendor may ship a `font` or a kind of its own before
 the specification names it.
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -307,7 +307,9 @@ pub fn resource_fits(resource: &Resource, artifact: &Artifact) -> bool {
 /// Resources section says: for each thing the entries describe (see
 /// [`Resource::identities`]), those that fit the artifact and, of them,
 /// the most specific. Entries for different things never hide one
-/// another. Document order is kept, and an entry that describes several
+/// another. Document order is kept as the final tie-breaker within each
+/// source type; consumers apply source priority before trying alternatives.
+/// An entry that describes several
 /// things, such as an `exec` completion for several shells, appears
 /// once.
 pub fn select_resources<'a>(statement: &'a Statement, artifact: &Artifact) -> Vec<&'a Resource> {
@@ -2958,6 +2960,30 @@ mod tests {
             Some(".well-known/packslip/oxlint.json")
         );
         assert_eq!(github_list_path("mise.jdx.dev"), None);
+    }
+
+    #[test]
+    fn resource_ties_preserve_document_order() {
+        let mut doc = sample();
+        doc.predicate.resources = ["first", "second"]
+            .map(|path| Resource {
+                name: Some("guide".into()),
+                archive: Some(path.into()),
+                ..Resource::new("skill")
+            })
+            .to_vec();
+        let artifact = &doc.predicate.artifacts[0];
+        assert_eq!(
+            select_resources(&doc, artifact),
+            doc.predicate.resources.iter().collect::<Vec<_>>()
+        );
+        doc.predicate.resources.swap(0, 1);
+        assert_eq!(
+            select_resources(&doc, &doc.predicate.artifacts[0])[0]
+                .archive
+                .as_deref(),
+            Some("second")
+        );
     }
 
     #[test]


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Spec and comment-only Rust changes plus a test; no install or verification logic changes in the diff.
> 
> **Overview**
> Clarifies how packslip consumers pick among **duplicate resource entries** for the same kind and identity after platform specificity and source-type priority.
> 
> The spec now states that **`resources` array order** is the final tie-breaker: equally scoped entries of the same source type form an ordered fallback list (first fetch/run wins; stop once satisfied). **Digest or commit mismatches still fail the install**—they are not treated like a missing file. Static **`cli-spec`** sources explicitly follow the same **archive → asset → repo** ordering, with document order breaking ties within each type.
> 
> The reference **`select_resources`** docs are aligned with that wording, and a unit test asserts tied archive entries stay in manifest order when selection runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b277691420db8f353c2fa1773071eaedeb097b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->