### PR TITLE
docs: explain release workflow and clarify publishing guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ and find executables, resources, and build provenance.
 
 ## Start here
 
+[How packslip fits a release](https://packslip.dev/docs/release-workflow/)
+explains the path from local build files to signed metadata and installation,
+including which parts belong to the publisher, CLI, and consumer.
+
 - **Try it locally:** [Getting started](https://packslip.dev/docs/getting-started/)
   walks through creating and verifying a manifest without a CI account.
 - **Publish a release:** [GitHub Actions](https://packslip.dev/docs/publishing/)

--- a/content/_index.md
+++ b/content/_index.md
@@ -13,6 +13,9 @@ A GitHub release job can sign with its workflow identity. Publishers
 outside supported CI can use an Ed25519 key. Both produce an in-toto
 statement in a sigstore bundle.
 
+[Follow the release workflow](/docs/release-workflow/) to see how local
+configuration becomes a signed bundle and how consumers find it.
+
 ## Inside a packslip
 
 Here is the release statement for a small portable tool, shortened to

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -4,23 +4,38 @@ description: Guides and reference for publishing and verifying packslip release 
 ---
 # Documentation
 
-Start with a working example, then add the metadata your release needs.
-The guides explain the workflow; the specification defines the format
-and the rules consumers must follow.
+Choose a path based on whether you publish software, install it, or build
+an integration. For the relationship between configuration, signing, and
+discovery, read [How packslip fits a release](/docs/release-workflow/).
 
-## Guides
+## Try packslip {#guides}
 
-| I want to… | Read |
-| --- | --- |
-| Create and verify my first packslip | [Getting started](/docs/getting-started/) |
-| Add packslip to a GitHub release job | [Publish with GitHub Actions](/docs/publishing/) |
-| Configure platforms and executable paths | [Artifact configuration](/docs/describing-releases/) |
-| Ship completions, skills, or desktop files | [Resources](/docs/resources/) |
-| Declare dependencies and minimum OS versions | [Host requirements](/docs/host-requirements/) |
-| Adapt a common release layout | [Release recipes](/docs/recipes/) |
-| Verify downloads or build a consumer | [Verify a release](/docs/verifying/) |
-| Use packslip with mise | [Using packslip with mise](/docs/mise/) |
-| Publish a release index or withdraw a version | [Manage release lists](/docs/release-lists/) |
+[Getting started](/docs/getting-started/) creates and verifies a small local
+release. It needs no CI account or connection to the signing services once
+the CLI is installed.
+
+## Publish software
+
+Follow these guides in the order your release needs them:
+
+1. [Artifact configuration](/docs/describing-releases/): describe platforms,
+   executable paths, and variants, using flags or a TOML manifest.
+2. [Resources](/docs/resources/) and [host requirements](/docs/host-requirements/):
+   describe additional files and what the host must provide.
+3. [Release recipes](/docs/recipes/): adapt a Rust, Go, monorepo, or desktop layout.
+4. [Publish with GitHub Actions](/docs/publishing/): sign and upload the bundle
+   from your release job.
+5. [Manage release lists](/docs/release-lists/): publish discovery metadata,
+   withdraw versions, and recommend a default release.
+
+## Install software or build a consumer
+
+- [Using packslip with mise](/docs/mise/) shows artifact installation,
+  completions, skills, and trust continuity in a consumer.
+- [Verify a release](/docs/verifying/) explains trusted identities, file
+  verification, and the additional policy an installer must enforce.
+- [Consumer rules](/release/v1/#consumer-rules) define the complete contract.
+  A successful CLI verification alone does not implement that contract.
 
 ## Reference
 

--- a/content/docs/describing-releases.md
+++ b/content/docs/describing-releases.md
@@ -9,6 +9,13 @@ A packslip describes the files you already build. Start with artifact
 paths and executable names, then add explicit metadata wherever your
 filenames or archive layouts leave room for ambiguity.
 
+## Choose flags or a manifest
+
+Use CLI flags when all artifacts share executable names and resource layouts.
+Use `release.toml` when individual files need different paths, platforms,
+requirements, or formats. Both produce the same signed release statement;
+TOML is configuration for the generator, not a second interchange format.
+
 ## Select platforms and variants
 
 `create` infers OS, architecture, libc, and format from artifact names.
@@ -36,6 +43,18 @@ An absent platform field means no restriction on that dimension. A
 universal macOS binary has `os = "darwin"` with no `arch`; it does not run
 on every OS. Use `portable = true` only when all platform fields should
 be absent.
+
+### Check inferred metadata
+
+Inference reads filenames, not your build configuration. An ambiguous name
+can leave a platform field unrestricted or describe the wrong target.
+For Linux artifacts, the generator defaults libc to `gnu` unless overridden
+or declared portable. Inspect the generated statement and set explicit
+values for anything the filename does not establish.
+
+`os`, `arch`, and `libc` describe where a build runs. `variant` distinguishes
+builds a user chooses, such as `fips` or `debug`. A minimum OS or glibc version
+belongs in `requires`, checked after selection; it cannot break an artifact tie.
 
 ## Name the executables
 
@@ -94,6 +113,22 @@ packslip create --manifest release.toml --out dist
 For local key signing, add `--key release.key`. In the action, set
 `manifest: release.toml` and still supply the required `artifacts` input.
 
+### Paths in the input and output
+
+| Field | Interpreted relative to | Example |
+| --- | --- | --- |
+| Artifact `path` | The working directory running `create`. | `dist/mytool-linux-x64.tar.gz` |
+| Resource `asset` in TOML | The same working directory. | `dist/mytool.cdx.json` |
+| Executable path or resource `archive` | The true archive root, retaining its top-level directory. | `mytool-1.2.3/bin/mytool` |
+| Resource `repo` | The source repository at `source.commit`. | `skills/mytool` |
+| Resource `artifact` | An exact artifact filename in the statement, with no local directory. | `mytool-linux-x64.tar.gz` |
+
+In the output, an asset's local path becomes its filename in `subject`.
+Its URL tells the consumer where to download it. Do not put `dist/` in an
+`archive` path unless that directory is actually inside the archive.
+
+### Defaults and overrides
+
 Configuration follows these rules:
 
 - Local artifact and asset paths are relative to the **working directory**,
@@ -147,4 +182,3 @@ skills, SBOMs, and desktop files.
 
 See [Host requirements](/docs/host-requirements/) for shared-library
 scanning, required commands, and minimum OS versions.
-

--- a/content/docs/publishing.md
+++ b/content/docs/publishing.md
@@ -9,12 +9,19 @@ The `jdx/packslip` action signs a manifest with your workflow's identity
 and uploads the bundle to an existing GitHub release. No long-lived
 signing key is needed.
 
+## Prepare the files and release
+
+The action consumes final local files. In a build matrix, collect the artifacts
+into the signing job before running it. Complete any archive rewriting,
+platform signing, or notarization that changes the bytes first.
+
+Create the GitHub release and upload the artifacts through your existing
+workflow. Upload separate resource assets, such as SBOMs, too. The action
+uploads only the packslip bundle; a signed URL does not upload its target.
+
 ## Add the release step
 
-Use this fragment in your release job. The artifacts must already exist
-on the runner, and the GitHub release must exist before the upload step.
-Upload your binaries through your existing release workflow; this action
-uploads the packslip bundle only.
+Use this fragment after those preparation steps in your release job.
 
 ```yaml
 permissions:
@@ -118,8 +125,32 @@ The action passes project, version, source, and URL metadata as CLI flags,
 which take precedence over the corresponding manifest values. Change
 those values through action inputs where available.
 
-## Check the result
+## Check the published result {#check-the-result}
 
-Download the bundle and one release artifact, then follow
-[Verify a release](/docs/verifying/). Verification of the packslip does
-not verify the linked provenance; consumers must check that separately.
+The action verifies the local bundle before uploading it. Check the published
+release separately: download the bundle and an artifact from the URLs users
+will use, then [verify both](/docs/verifying/#verify-against-the-expected-repository)
+against your repository identity. This also catches a wrong upload, stale file,
+or URL that points at a different build.
+
+Inspect the statement with `packslip show` to confirm the project, normalized
+version, source tag, platforms, and executable paths. Inspection does not
+replace verification. Linked build provenance also needs its own verification;
+the packslip verification command does not fetch it.
+
+For a draft workflow trial, set `upload: false` to retain the bundle locally.
+This still signs the statement and, with the default `attest: true`, publishes
+provenance. Use the [local walkthrough](/docs/getting-started/) for an offline
+trial that does not contact signing services.
+
+## Troubleshoot publication
+
+| Symptom | What to check |
+| --- | --- |
+| No artifacts matched | Files must be present in this job's working directory. Download matrix outputs before the action, and check the glob. |
+| Version rejected | Pass a semver `version` explicitly for tags such as `mytool-v1.2.3` or `v4.1`. |
+| Executable missing or ambiguous | Check the archive contents and use an explicit path or `NAME=PATH` mapping. |
+| Bundle upload fails | The release named by `tag` must exist and the token must have `contents: write`. |
+| Signing cannot obtain a CI identity | Give the signing job `id-token: write`. |
+| A resource URL returns a missing file | Upload that separate asset; resource declarations only describe it. |
+| A download fails its digest check | Compare the published file with the final local file that was signed; do not disable verification. |

--- a/content/docs/release-lists.md
+++ b/content/docs/release-lists.md
@@ -26,6 +26,16 @@ mappings, and a signed recommendation. Other forges need the discovery
 mechanism described in the [specification](/release/v1/#discovery);
 a recognized signing issuer alone does not provide a release index.
 
+### GitHub lists supplement release discovery
+
+A GitHub list overrides the releases it names; it does not replace the
+repository's release index. An omitted version can still be discovered from
+its tag. To withdraw a release, keep it in the list with a yanked status.
+
+This differs from a project on its own domain, where the signed list supplies
+the release index. In both cases, consumers require a previously accepted
+signed list to remain available, valid, and current.
+
 ## Create the list
 
 Keep local copies of the released bundles. Each `--release` pairs the
@@ -106,3 +116,17 @@ the vendor's pin. A mirror or repackager that signs its own release
 manifest makes a different claim. See
 [lists from other publishers](/release/v1/#lists-from-other-publishers)
 and [repackager attestation](/release/v1/#repackager-attestation).
+
+## Diagnose a release that is not offered
+
+| Symptom | What to check |
+| --- | --- |
+| A domain project has no releases | Publish the signed list at the well-known path, including the project subpath. |
+| A GitHub tag is invisible | Check that it maps to a version for this project, or add an explicit version/tag mapping in the signed list. |
+| A release is found but refused | Verify its bundle and confirm the signed project, version, and bundle digest match discovery metadata. |
+| A withdrawn version reappears | Keep its yanked entry; omission from a supplementary GitHub list does not withdraw it. |
+| The list expires without a new release | Re-sign the retained entries with a later expiry and increased sequence. |
+| `latest` selects another version | Check whether the recommendation is eligible under withdrawal, prerelease, age, stamping, and host policy. |
+
+These are consumer discovery checks. `packslip verify` alone does not fetch
+an index, enforce its expiry, or remember its previously accepted sequence.

--- a/content/docs/release-workflow.md
+++ b/content/docs/release-workflow.md
@@ -1,0 +1,98 @@
+---
+title: How packslip fits a release
+weight: 5
+description: Follow release files from local configuration to a signed bundle, discovery, and verified installation.
+---
+# How packslip fits a release
+
+packslip adds a signed description to the release files you already build.
+Your build produces the software; packslip records what shipped; a consumer
+uses that record to choose and verify a download.
+
+## From build to installation
+
+1. **Build and package.** Produce the final archives, executables, installers,
+   and separate resource files. Finish any platform signing or notarization
+   that changes those files before creating the packslip.
+2. **Describe and sign.** Give `packslip create` the local files and release
+   metadata. It hashes the files, records their platform and layout, and
+   signs the resulting statement with a CI identity or an Ed25519 key.
+3. **Publish.** Upload the bundle, artifacts, and separate resource assets.
+   The URLs in the statement must point to the exact bytes that were hashed.
+4. **Make the release discoverable.** On GitHub, attach the bundle to the
+   release. For a project on its own domain, publish a signed release list
+   at the project's well-known URL.
+5. **Verify and install.** The consumer finds an eligible release, verifies
+   its signer and metadata against the requested project, chooses an artifact,
+   and checks the downloaded bytes before unpacking or running them.
+
+The CLI covers creation and verification of individual documents and local
+files. An installer adds discovery, artifact selection, installation, and
+remembered trust policy. See [verification](/docs/verifying/) for that boundary
+and [mise](/docs/mise/) for a consumer example.
+
+## Three documents with different jobs
+
+The word *manifest* can mean the publisher's input or the signed release
+record. They are different files:
+
+| Document | Who creates it | What it contains | Where it belongs |
+| --- | --- | --- | --- |
+| `release.toml` | The publisher | Local paths, metadata overrides, and resource declarations for `create --manifest`. | In the source repository or build workspace; it is optional. |
+| `packslip.sigstore.json` | `packslip create` | One release statement, its signature, and verification material. | Beside the published release files. |
+| `packslip.json` | `packslip releases` | A signed list of release bundles, their digests, and discovery policy such as withdrawals. | At the project's discovery location. |
+
+`release.toml` is not the document consumers verify. Creation resolves its
+local paths into subject names, digests, download URLs, and artifact metadata.
+Uploading the TOML alone does not publish a packslip.
+
+A release bundle contains a **statement** inside a **sigstore bundle**. The
+statement's `subject` lists file digests; its `predicate` holds the project,
+version, artifacts, and resources. `packslip show` displays that inner statement
+without verifying it. The JSON schemas describe the inner statements, not the
+TOML input or the outer bundle.
+
+## Identity, version, and location
+
+Keep these values distinct when configuring a release:
+
+| Value | Example | Purpose |
+| --- | --- | --- |
+| Project | `github.com/owner/repo/mytool` | Names the tool the consumer requested. It has no URL scheme. |
+| Version | `1.2.3` | The release's semver version, used for selection. |
+| Source tag | `mytool-v1.2.3` | Preserves the publisher's tag spelling. |
+| Artifact URL | `https://downloads.example.com/mytool/1.2.3/mytool-linux-x64.tar.gz` | Locates bytes whose digest is in the signed statement. |
+| Signer | A workflow identity and issuer, or a trusted public key | Authenticates the statement. |
+
+A monorepo subpath names a tool; its GitHub signer is still pinned to the
+repository. A download host locates files; it does not replace the signer pin.
+Consumers check both the expected signer and the signed project and version.
+
+The format requires semver even when a publisher's tag uses another spelling.
+For example, a tag `v4.1` can describe version `4.1.0`. Pass the normalized
+version explicitly when creating such a release; do not assume the action
+normalizes arbitrary tags. See [version spelling](/release/v1/#spelling-a-version)
+for supported mappings and their limits.
+
+## What changes after publication
+
+Treat an individual release bundle and the files it describes as the record
+of that release. Changing an archive after signing breaks its digest match.
+Changing the bundle also changes the digest recorded in any signed release list.
+
+Use a **new release** for changed software. Use a **new signed release list**
+to withdraw a release, mark a security fix, recommend a default version, or
+refresh discovery metadata. List updates need an increased sequence and a
+current expiry; they do not re-sign or replace the individual release bundles.
+
+A GitHub list is supplementary: versions omitted from it can still be found
+through GitHub releases. Keep an explicit yanked entry to withdraw a version;
+omitting the entry does not withdraw it. See [release lists](/docs/release-lists/).
+
+## Put it into practice
+
+- [Getting started](/docs/getting-started/) creates and verifies a local sample.
+- [Artifact configuration](/docs/describing-releases/) maps your release layout
+  to executable paths, platforms, and variants.
+- [Publish with GitHub Actions](/docs/publishing/) adds signing to a release job.
+- [Manage release lists](/docs/release-lists/) covers discovery and ongoing updates.

--- a/content/docs/resources.md
+++ b/content/docs/resources.md
@@ -83,10 +83,9 @@ for platform-specific resources. Use `artifact = "FILENAME"` for a
 resource that belongs to a particular archive format or variant, as in the example below.
 
 For the same resource, exact artifact scope wins over platform scope.
-Consumers then prefer the most specific platform scope, followed by the
-source order: archive, asset, repo, exec. Different commands, shells,
-and named skills remain separate resources.
-
+Consumers then prefer the most specific platform scope before considering
+the source type. Different commands, shells, and named skills remain
+separate resources.
 
 ```toml
 [[resource]]
@@ -98,3 +97,44 @@ archive = "mytool-1.2.3/share/man/man1/mytool.1"
 This man page belongs only to the named archive, not to another format or
 variant for the same platform. For complete configurations, see the
 [release recipes](/docs/recipes/).
+
+## Provide fallbacks deliberately
+
+Consumers group entries by resource identity before selecting a source.
+For completions that identity is the executable and shell; for a CLI spec,
+it is the executable and format; for a skill, it is the skill name. A bash
+completion and a zsh completion are separate needs, not fallback choices.
+
+Within one identity, selection proceeds in this order:
+
+1. Keep entries that apply to the selected artifact.
+2. Prefer exact artifact scope, then the most specific platform scope.
+3. Prefer `archive`, then `asset`, then `repo` sources. For a need a static
+   CLI spec can generate, try that before running an `exec` resource.
+4. Break ties within the same scope and source type by declaration order.
+   Stop once a usable entry satisfies the need.
+
+For example, these equally scoped entries try the current skill directory
+first and the older location only if the first is unavailable. The release
+must also declare `source.repo` and `source.commit`.
+
+```toml
+[[resource]]
+kind = "skill"
+name = "mytool"
+repo = "skills/mytool"
+
+[[resource]]
+kind = "skill"
+name = "mytool"
+repo = ".agents/skills/mytool"
+```
+
+Do not use fallback to hide an incorrectly scoped path: less specific entries
+have already been removed before sources are tried. Scope an archive resource
+to its artifact when other artifacts do not contain that path.
+
+An unavailable optional resource is reported and may leave the installation
+without that resource. A digest or source-commit mismatch fails the installation;
+it never permits trying a different source. See the full
+[resource selection rules](/release/v1/#resources).

--- a/content/spec.md
+++ b/content/spec.md
@@ -302,7 +302,11 @@ Windows installer.
 
 ### Field reference
 
-| Field | Type | | Meaning |
+Required fields inside an optional object are required when that object is
+present. For example, `source` is optional, but a supplied `source` must
+include `repo`. Resource entries must choose exactly one source field.
+
+| Field | Type | Presence | Meaning |
 |---|---|---|---|
 | `_type` | string | required | Always `https://in-toto.io/Statement/v1`. |
 | `subject[]` | array | required | One entry per artifact and per resource asset. |
@@ -361,8 +365,11 @@ Windows installer.
 `resources` describes files and generated content associated with the
 release: completions, man pages, CLI specifications, agent skills, SBOMs,
 and desktop integration files. Each entry has a `kind` and exactly one
-source. After applying scope and specificity, consumers prefer sources
-in this order:
+source.
+
+### Source types
+
+After applying scope and specificity, consumers prefer sources in this order:
 
 - `archive`: a path inside the artifact the consumer selected, from the
   true archive root. The artifact's digest already covers it.
@@ -379,6 +386,8 @@ in this order:
   case: cobra, clap, oclif, and usage generate completions from the
   binary and ship no file. What matters is when it runs, and Running an
   exec entry says so. A vendor with a static file lists it first.
+
+### Scope and identity
 
 Layouts differ by platform more often than by file, so an entry may carry
 `os`, `arch`, or `libc` to say which artifacts it describes; an entry
@@ -416,7 +425,7 @@ two equally scoped `repo` entries for one skill try the first directory,
 then the second only if the first is unavailable. A verification failure
 still refuses the release; it is not a reason to try an alternative.
 
-Documented kinds:
+### Resource kinds
 
 - `completion`: a shell completion script. With a static source, `shell`
   names the shell: `bash`, `zsh`, `fish`, `powershell`, `nushell`,
@@ -460,6 +469,8 @@ Documented kinds:
   gives its size.
 - `app`: a macOS application bundle inside a `dmg` or `zip`, by its path
   in the archive, which a consumer copies to Applications. Archive only.
+
+### Fallback and verification
 
 For any one need, a consumer takes the first source it can use in the
 order above: an `archive` or `asset` entry, then `repo`, then one derived

--- a/docs/spec/packslip.md
+++ b/docs/spec/packslip.md
@@ -298,7 +298,11 @@ Windows installer.
 
 ### Field reference
 
-| Field | Type | | Meaning |
+Required fields inside an optional object are required when that object is
+present. For example, `source` is optional, but a supplied `source` must
+include `repo`. Resource entries must choose exactly one source field.
+
+| Field | Type | Presence | Meaning |
 |---|---|---|---|
 | `_type` | string | required | Always `https://in-toto.io/Statement/v1`. |
 | `subject[]` | array | required | One entry per artifact and per resource asset. |
@@ -357,8 +361,11 @@ Windows installer.
 `resources` describes files and generated content associated with the
 release: completions, man pages, CLI specifications, agent skills, SBOMs,
 and desktop integration files. Each entry has a `kind` and exactly one
-source. After applying scope and specificity, consumers prefer sources
-in this order:
+source.
+
+### Source types
+
+After applying scope and specificity, consumers prefer sources in this order:
 
 - `archive`: a path inside the artifact the consumer selected, from the
   true archive root. The artifact's digest already covers it.
@@ -375,6 +382,8 @@ in this order:
   case: cobra, clap, oclif, and usage generate completions from the
   binary and ship no file. What matters is when it runs, and Running an
   exec entry says so. A vendor with a static file lists it first.
+
+### Scope and identity
 
 Layouts differ by platform more often than by file, so an entry may carry
 `os`, `arch`, or `libc` to say which artifacts it describes; an entry
@@ -412,7 +421,7 @@ two equally scoped `repo` entries for one skill try the first directory,
 then the second only if the first is unavailable. A verification failure
 still refuses the release; it is not a reason to try an alternative.
 
-Documented kinds:
+### Resource kinds
 
 - `completion`: a shell completion script. With a static source, `shell`
   names the shell: `bash`, `zsh`, `fish`, `powershell`, `nushell`,
@@ -456,6 +465,8 @@ Documented kinds:
   gives its size.
 - `app`: a macOS application bundle inside a `dmg` or `zip`, by its path
   in the archive, which a consumer copies to Applications. Archive only.
+
+### Fallback and verification
 
 For any one need, a consumer takes the first source it can use in the
 order above: an `archive` or `asset` entry, then `repo`, then one derived

--- a/scripts/check-docs.py
+++ b/scripts/check-docs.py
@@ -44,7 +44,7 @@ def check_links(site):
     pages = {path.resolve(): Page(path) for path in site.rglob("*.html")}
     required = ["index.html", "release/v1/index.html", "docs/index.html", "cli/index.html"]
     required += [f"docs/{name}/index.html" for name in (
-        "getting-started", "describing-releases", "resources", "host-requirements",
+        "release-workflow", "getting-started", "describing-releases", "resources", "host-requirements",
         "recipes", "publishing", "verifying", "release-lists", "mise",
     )]
     errors = [f"missing page: {name}" for name in required if not (site / name).is_file()]


### PR DESCRIPTION
Readers could follow individual commands but still had to piece together how local TOML configuration, a signed release bundle, discovery metadata, and consumer policy fit together. Add a release workflow guide and organize the documentation entry point around trying, publishing, and consuming releases.

The guides now explain local versus archive paths, platform inference and overrides, final-file publication order, resource fallback and verification failures, and the supplementary nature of GitHub release lists. Add publication and discovery troubleshooting, divide the specification's resources section into navigable subsections, and clarify required fields inside optional objects. Preserve existing guide URLs and section anchors and regenerate the spec page.

Based on `main` after #52 and #50 merged; the preceding stack has landed.

## Validation

- `RUSTUP_TOOLCHAIN=1.95.0 mise run docs:check`: 21 pages and 740 local links, anchors, and assets; offline quickstart including tamper rejection; four recipe manifests.
- Inspected the rendered documentation index, workflow guide, and comparison table in the browser.
- `git diff --check` passes.

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and spec presentation only; no changes to the CLI, action, or verification behavior.
> 
> **Overview**
> Adds **[How packslip fits a release](/docs/release-workflow/)** as the spine from local build → signed bundle → discovery → verified install, including how `release.toml`, `packslip.sigstore.json`, and `packslip.json` differ and what the CLI vs a full consumer does.
> 
> **README**, the site home page, and the **docs index** now point at that guide and reorganize entry paths into try, publish (ordered steps), and install/consume, with an explicit note that CLI `verify` is not the full consumer contract.
> 
> Existing guides gain operational detail: artifact **flags vs TOML**, **inference pitfalls**, a **path resolution** table; GitHub Actions **prep order** (final bytes, matrix artifacts), **post-upload checks**, and a **publication troubleshooting** table; **supplementary GitHub release lists** vs domain indexes plus **discovery diagnostics**; **resource fallback** selection order and verification vs fetch failures.
> 
> The **spec** Resources section is split into subsections; the field table adds a **Presence** column and clarifies required fields inside optional objects. **`scripts/check-docs.py`** requires the new `release-workflow` page in the built site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9ce6bd0b5fd7a288a325fcd4ed4a892d900cc0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->