### PR TITLE
feat(release): notarize macOS, ship Windows arm64, publish through Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,18 +50,33 @@ jobs:
           - target: aarch64-unknown-linux-musl
             runner: ubuntu-24.04-arm
             asset: linux-arm64
+          # macOS is arm64 only. Every Mac Apple sells runs Apple silicon,
+          # and Rosetta 2 runs this binary on the Intel machines that are
+          # left, so an x64 build would be a second signed and notarized
+          # artifact serving a shrinking audience.
           - target: aarch64-apple-darwin
             runner: macos-latest
             asset: darwin-arm64
-          - target: x86_64-apple-darwin
-            runner: macos-latest
-            asset: darwin-x64
           - target: x86_64-pc-windows-msvc
             runner: windows-latest
             asset: windows-x64
+          # Built natively rather than cross-compiled from the x64 image:
+          # aws-lc-sys compiles C and assembly for the host toolchain, and
+          # arranging an ARM64 MSVC cross-build is more moving parts than a
+          # runner that is already the target.
+          - target: aarch64-pc-windows-msvc
+            runner: windows-11-arm
+            asset: windows-arm64
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v5
+      # The Developer ID certificate has to be in the keychain before the
+      # signing step below can find it.
+      - if: contains(matrix.target, 'apple')
+        uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7
+        with:
+          p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
+          p12-password: ${{ secrets.CERTIFICATES_P12_PASS }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -78,6 +93,75 @@ jobs:
           CC_x86_64_unknown_linux_musl: musl-gcc
           CC_aarch64_unknown_linux_musl: musl-gcc
           AWS_LC_SYS_PREBUILT_NASM: "1"
+      # Signing settles who built the binary; notarization is what Gatekeeper
+      # demands once a download carries the quarantine bit, which is to say
+      # whenever someone fetches it in a browser rather than with curl.
+      # Without a ticket it is blocked behind a "cannot be verified" dialog
+      # that only a deliberate override gets past.
+      #
+      # The ticket lives on Apple's side and is keyed to the binary's cdhash,
+      # so notarizing does not rewrite the file that gets packaged below.
+      # Stapling would, but `stapler` only writes into bundles, disk images,
+      # and installer packages, and this is a bare Mach-O in an archive;
+      # Gatekeeper resolves the ticket online instead.
+      - name: Sign and notarize the macOS binary
+        if: contains(matrix.target, 'apple')
+        shell: bash
+        env:
+          BINARY: target/${{ matrix.target }}/release/packslip
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$APPLE_API_KEY_P8" ] || [ -z "$APPLE_API_KEY_ID" ] || [ -z "$APPLE_API_ISSUER_ID" ]; then
+            echo "::error title=Notarization credentials missing::App Store Connect credentials are required for macOS releases."
+            exit 1
+          fi
+
+          # --options runtime and --timestamp are what the notary service
+          # requires; without them a submission comes back Invalid.
+          codesign -f --options runtime --timestamp --prefix dev.jdx. \
+            -s "Developer ID Application: Jeffrey Dickey (4993Y37DX6)" "$BINARY"
+          codesign --verify --strict --verbose=2 "$BINARY"
+
+          # Outside the workspace, so no later step can sweep the key into an
+          # artifact, and removed even when notarization fails.
+          work="$(mktemp -d)"
+          trap 'rm -rf "$work"' EXIT
+          printf '%s' "$APPLE_API_KEY_P8" | base64 --decode > "$work/key.p8"
+
+          # notarytool takes a container, never a bare executable. A copy is
+          # fine: a Mach-O carries its signature inline, so the cdhash the
+          # ticket is keyed to is the one that ships.
+          mkdir "$work/stage"
+          cp "$BINARY" "$work/stage/"
+          ditto -c -k --norsrc --noextattr "$work/stage" "$work/submission.zip"
+
+          # `--wait` is not a gate on its own: it can return zero on an
+          # Invalid submission, so the reported status is what decides.
+          # plutil reads JSON and ships with macOS, which keeps this off jq.
+          result="$(xcrun notarytool submit "$work/submission.zip" \
+            --key "$work/key.p8" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" \
+            --output-format json \
+            --timeout 30m \
+            --wait)"
+          echo "$result"
+
+          status="$(printf '%s' "$result" | plutil -extract status raw -o - -)"
+          id="$(printf '%s' "$result" | plutil -extract id raw -o - -)"
+          if [ "$status" != "Accepted" ]; then
+            echo "::error::notarization returned $status for submission $id"
+            xcrun notarytool log "$id" \
+              --key "$work/key.p8" \
+              --key-id "$APPLE_API_KEY_ID" \
+              --issuer "$APPLE_API_ISSUER_ID" || true
+            exit 1
+          fi
+          echo "notarized: submission $id"
       - name: Package
         shell: bash
         env:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,9 +12,8 @@ enabled as described below.
    changelog generated from conventional commits through `cliff.toml`.
    The workflow also regenerates the CLI documentation in that PR.
 2. A maintainer reviews and merges the PR.
-3. If `RELEASE_PLZ_RELEASE` is `true`, the release job creates the
-   `vX.Y.Z` tag. When crate publishing is enabled in `release-plz.toml`,
-   it publishes to crates.io before tagging.
+3. If `RELEASE_PLZ_RELEASE` is `true`, the release job publishes the crate
+   to crates.io and then creates the `vX.Y.Z` tag.
 4. The tag triggers `release.yml`, which checks that the tag matches
    `Cargo.toml`, builds five platform binaries, signs and notarizes the
    macOS one, attests them all, and creates a draft GitHub release. It

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,15 +16,11 @@ enabled as described below.
    `vX.Y.Z` tag. When crate publishing is enabled in `release-plz.toml`,
    it publishes to crates.io before tagging.
 4. The tag triggers `release.yml`, which checks that the tag matches
-   `Cargo.toml` and builds five platform binaries,
-   attests them, and creates a draft GitHub release. It generates narrative
-   notes with Communiqué, publishes the release's packslip, publishes the
-   GitHub release, and moves the action's matching major tag (`v0` for
-   0.x releases, `v1` for 1.x releases, and so on).
-
-`publish = false` and `git_only = true` currently keep release-plz working
-from Git tags without publishing the crate. See the registry setup below
-before enabling crate publication.
+   `Cargo.toml`, builds five platform binaries, signs and notarizes the
+   macOS one, attests them all, and creates a draft GitHub release. It
+   generates narrative notes with Communiqué, publishes the release's
+   packslip, publishes the GitHub release, and moves the action's matching
+   major tag (`v0` for 0.x releases, `v1` for 1.x releases, and so on).
 
 The action reads its default CLI version from its own `Cargo.toml`, so
 the release PR's version bump also updates that default. The action and CLI
@@ -33,6 +29,38 @@ included in the Cargo package so release-plz detects those changes.
 Use conventional commits such as `fix(action): ...` or `feat(action): ...`;
 breaking action changes affect the shared version too.
 
+## Platforms
+
+| Asset           | Target                       | Runner             |
+| --------------- | ---------------------------- | ------------------ |
+| `linux-x64`     | `x86_64-unknown-linux-musl`  | `ubuntu-latest`    |
+| `linux-arm64`   | `aarch64-unknown-linux-musl` | `ubuntu-24.04-arm` |
+| `darwin-arm64`  | `aarch64-apple-darwin`       | `macos-latest`     |
+| `windows-x64`   | `x86_64-pc-windows-msvc`     | `windows-latest`   |
+| `windows-arm64` | `aarch64-pc-windows-msvc`    | `windows-11-arm`   |
+
+There is no `darwin-x64` asset. Rosetta 2 runs the arm64 binary on the
+Intel Macs that remain, which is a better trade than signing, notarizing,
+and supporting a second macOS artifact.
+
+Windows arm64 is built on a native arm64 runner rather than cross-compiled,
+because `aws-lc-sys` — the crypto behind rustls — compiles C and assembly
+for the host toolchain.
+
+## macOS signing and notarization
+
+The macOS binary is signed with the `Developer ID Application: Jeffrey
+Dickey (4993Y37DX6)` certificate under `--options runtime --timestamp`,
+which the notary service requires, and then submitted to `notarytool`.
+The reported status must be `Accepted` or the job fails; `--wait` is not a
+gate on its own, since it can return zero on an `Invalid` submission.
+
+Nothing is stapled: `stapler` writes only into bundles, disk images, and
+installer packages, and this is a bare Mach-O inside an archive. The ticket
+is keyed to the binary's cdhash and lives on Apple's side, so Gatekeeper
+resolves it online. That is what keeps a browser download from being held
+behind the "cannot be verified" dialog.
+
 ## Repository setup
 
 | Setting | Purpose |
@@ -40,24 +68,25 @@ breaking action changes affect the shared version too.
 | Secret `RELEASE_PLZ_TOKEN` | Fine-grained token with repository contents and pull-request write permissions. The workflows use it so generated PRs and tags can trigger subsequent workflows. |
 | Secret `ANTHROPIC_API_KEY` | Lets Communiqué generate release notes. If generation fails or the key is unavailable, publication continues with GitHub's generated notes. |
 | Variable `RELEASE_PLZ_RELEASE=true` | Enables the release job. Without it, merging the release PR does not publish a release. |
+| Secrets `CERTIFICATES_P12`, `CERTIFICATES_P12_PASS` | The base64-encoded Developer ID Application certificate and its export password, the same pair the other jdx.dev CLIs use. The macOS build fails at signing without them. |
+| Secrets `APPLE_API_KEY_P8`, `APPLE_API_KEY_ID`, `APPLE_API_ISSUER_ID` | A base64-encoded App Store Connect API key and its key and issuer IDs. The macOS job fails early and by name when any is missing, rather than shipping an unnotarized binary. |
 
 Communiqué's context and tone are configured in `communique.toml`.
 Its version is declared in `mise.toml` and resolved in `mise.lock`;
 update the lock deliberately with `mise lock`.
 
-## Enable crates.io publication
+## crates.io publication
 
-The first crate publication is manual. release-plz cannot plan against a
-missing registry crate when a version tag already exists.
+crates.io needs no stored credential. 0.2.0 was published by hand from its
+tag to create the crate — Trusted Publishing cannot create one — and a
+Trusted Publisher is registered for repository `jdx/packslip`, workflow
+`release-plz.yml`. The release job mints a short-lived token through OIDC
+with `rust-lang/crates-io-auth-action`, so the API token used for that
+first publish was revoked immediately afterwards.
 
-1. Run `cargo publish` from the intended tagged commit using a crates.io
-   API token.
-2. Register a Trusted Publisher for repository `jdx/packslip` and workflow
-   `release-plz.yml`.
-3. Set `publish = true` in `release-plz.toml` and review its `git_only`
-   setting for the intended release baseline.
-4. Enable `RELEASE_PLZ_RELEASE` when the repository is ready to publish
-   merged release PRs.
+`publish = true` in `release-plz.toml` follows from that, and `git_only` is
+gone with it: release-plz measures a release against the registry rather
+than against the last Git tag.
 
 ## Tags and verification
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -5,16 +5,11 @@
 git_release_enable = false
 git_tag_enable = true
 git_tag_name = "v{{ version }}"
-# Off until the crate has been published to crates.io once by hand and a
-# Trusted Publisher is registered; then flip to true (RELEASING.md).
-# While off, release-plz measures the release against the last git tag
-# rather than the registry.
-publish = false
+# 0.2.0 was published by hand to create the crate, and a Trusted Publisher
+# is registered for jdx/packslip's release-plz.yml, so the release job mints
+# a short-lived token through OIDC and needs no stored credential.
+publish = true
 # A binary crate: its library API is not a compatibility promise.
 semver_check = false
 # release-plz ignores cliff.toml unless told about it.
 changelog_config = "cliff.toml"
-
-# Measure releases against git tags, not crates.io, which does not have
-# the crate yet.
-git_only = true


### PR DESCRIPTION
Three changes that finish the release path.

## macOS is signed and notarized

The `darwin-arm64` binary is signed with `Developer ID Application: Jeffrey
Dickey (4993Y37DX6)` under `--options runtime --timestamp` — both required by
the notary service — and then submitted to `notarytool`. The reported status
has to be `Accepted` or the job fails: `--wait` returns zero on an `Invalid`
submission, so it is not a gate by itself. On failure the notary log is
dumped before exiting.

Nothing is stapled. The ticket is keyed to the binary's cdhash and lives on
Apple's side; `stapler` only writes into bundles, disk images, and installer
packages, and this is a bare Mach-O inside an archive, so Gatekeeper resolves
the ticket online. Without one, a browser download — anything that carries
the quarantine bit — sits behind the "cannot be verified" dialog.

This follows mise, the only other jdx.dev CLI that notarizes today; hk and
fnox stop at `codesign`.

## The platform set changes shape, not size

| Asset | Target | Runner |
| --- | --- | --- |
| `linux-x64` | `x86_64-unknown-linux-musl` | `ubuntu-latest` |
| `linux-arm64` | `aarch64-unknown-linux-musl` | `ubuntu-24.04-arm` |
| `darwin-arm64` | `aarch64-apple-darwin` | `macos-latest` |
| `windows-x64` | `x86_64-pc-windows-msvc` | `windows-latest` |
| `windows-arm64` | `aarch64-pc-windows-msvc` | `windows-11-arm` |

`darwin-x64` is gone: Rosetta 2 covers the Intel Macs that are left, and a
second signed and notarized macOS artifact is not worth its upkeep.

`windows-arm64` takes its place, built on a native arm64 runner rather than
cross-compiled from the x64 image. packslip pulls `aws-lc-sys` through
rustls, which compiles C and assembly for the host toolchain; a runner that
is already the target avoids arranging an ARM64 MSVC cross-build. (mise
cross-compiles this target on `windows-latest`, but it defaults to
native-tls and so never builds aws-lc.)

## crates.io publishes through Trusted Publishing

`packslip` 0.2.0 was published by hand from its tag, because Trusted
Publishing cannot create a crate, and the bootstrap API token was revoked
right after. With a Trusted Publisher registered for this repository's
`release-plz.yml`, the release job mints a short-lived token over OIDC, so
`publish = true` costs no stored credential. `git_only` goes with it —
release-plz can now measure a release against the registry rather than
against the last git tag.

The repository variable `RELEASE_PLZ_RELEASE` is set, so merging a release PR
now tags, publishes, and builds for real.

## Before merging a release

The macOS job needs `CERTIFICATES_P12`, `CERTIFICATES_P12_PASS`,
`APPLE_API_KEY_P8`, `APPLE_API_KEY_ID`, and `APPLE_API_ISSUER_ID` on this
repository. It fails by name when any are missing rather than shipping an
unnotarized binary.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.176.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the production release pipeline (new platform artifact, mandatory macOS notarization, and automatic crates.io publish); misconfiguration or missing secrets would block or mishandle releases, but application runtime code is untouched.
> 
> **Overview**
> **Release binaries** still ship five assets, but the matrix swaps **`darwin-x64` for `windows-arm64`** (native `windows-11-arm` build). macOS stays **arm64-only** with Rosetta called out as the Intel path.
> 
> The **`release.yml` macOS job** now imports the Developer ID cert, **signs** `packslip` with hardened runtime + timestamp, and **submits to `notarytool`**—the job fails if App Store Connect secrets are missing or status is not `Accepted` (with notary logs on failure). No stapling; online Gatekeeper ticket only.
> 
> **`release-plz.toml`** turns on **`publish = true`** and drops **`git_only`**, so releases are measured against crates.io after the hand-published 0.2.0 + Trusted Publisher setup documented in **`RELEASING.md`** (platform table, signing/notarization, and required Apple/certificate secrets).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 957fdc66d917435f265a78d42959a844813d5342. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a native Windows ARM64 release build.
  - macOS releases are now signed and notarized for improved installation and trust.
  - Release packages now target Apple silicon and Windows ARM64 alongside supported Linux and Windows platforms.

- **Documentation**
  - Updated release documentation with available platforms, packaging details, and macOS verification information.
  - Documented the streamlined crates.io publication process for future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->