### PR TITLE
feat(action): run a caller-supplied packslip CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,32 @@ The action and CLI share a version: `@v0` follows CLI 0.x releases, and
 version from its own commit's `Cargo.toml`. Set `packslip-version` to
 explicitly override that selection.
 
+### Bring your own CLI
+
+`packslip-path` runs an executable that is already on the runner — a
+path, or a name to look up on PATH — instead of downloading a release
+archive. macOS releases are arm64 only, so an x64 macOS job builds the
+CLI first and points the action at it:
+
+```yaml
+runs-on: macos-15-intel
+steps:
+  - uses: dtolnay/rust-toolchain@stable
+  - run: cargo install packslip --version 0.2.0 --locked --root "$RUNNER_TEMP/packslip"
+  - uses: jdx/packslip@v0.2.0
+    with:
+      packslip-path: ${{ runner.temp }}/packslip/bin/packslip
+      artifacts: dist/*.tar.xz
+      bin: mytool
+```
+
+Install the version the action ref pins; the two are released together.
+The same applies to any runner a release archive does not suit: a
+platform packslip does not ship, a self-hosted or network-restricted
+machine, or a job that would rather build from source than download.
+`packslip-path` takes precedence over `packslip-version`, and a binary
+the action did not download is not verified, so the job vouches for it.
+
 ## Work on packslip
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, checks, and documentation

--- a/action.yml
+++ b/action.yml
@@ -105,7 +105,18 @@ inputs:
   packslip-version:
     description: >
       The packslip release to run; defaults to the version this action was
-      released with (read from its Cargo.toml).
+      released with (read from its Cargo.toml). Ignored when packslip-path
+      is set.
+    required: false
+    default: ""
+  packslip-path:
+    description: >
+      An existing packslip executable to run instead of downloading a
+      release: a path, or a name to look up on PATH. For a platform with no
+      release asset the job can run, build the CLI first (`cargo install
+      packslip --locked --root "$RUNNER_TEMP/packslip"`) and point this at
+      it. The action runs the binary as given and does not check its
+      provenance, so the job is responsible for where it came from.
     required: false
     default: ""
   token:
@@ -126,35 +137,58 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.token }}
         PACKSLIP_VERSION: ${{ inputs.packslip-version }}
+        PACKSLIP_PATH: ${{ inputs.packslip-path }}
       run: |
         set -euo pipefail
-        version="${PACKSLIP_VERSION:-$(sed -nE 's/^version *= *"([^"]+)".*/\1/p' "${GITHUB_ACTION_PATH}/Cargo.toml" | head -n1)}"
-        [ -n "$version" ] || { echo "could not read the packslip version from Cargo.toml" >&2; exit 1; }
         case "$(uname -s)" in
-          Linux) os=linux ;;
-          Darwin) os=darwin ;;
-          MINGW*|MSYS*|CYGWIN*) os=windows ;;
+          Linux) os=linux; exe= ;;
+          Darwin) os=darwin; exe= ;;
+          MINGW*|MSYS*|CYGWIN*) os=windows; exe=.exe ;;
           *) echo "unsupported OS: $(uname -s)" >&2; exit 1 ;;
         esac
-        case "$(uname -m)" in
-          x86_64|amd64) arch=x64 ;;
-          aarch64|arm64) arch=arm64 ;;
-          *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
-        esac
-        if [ "$os" = windows ]; then ext=zip; else ext=tar.xz; fi
-        asset="packslip-v${version}-${os}-${arch}.${ext}"
         dir="${RUNNER_TEMP}/packslip-bin"
         mkdir -p "$dir"
-        gh release download "v${version}" -R jdx/packslip -p "$asset" -D "$dir" --clobber
-        # The archive was built by jdx/packslip's release workflow; check that before running it.
-        gh attestation verify "$dir/$asset" -R jdx/packslip
-        if [ "$ext" = zip ]; then
-          (cd "$dir" && unzip -oq "$asset")
+        if [ -n "$PACKSLIP_PATH" ]; then
+          # A binary the job built or installed itself: every later step
+          # runs it as `packslip`, whatever it is called here.
+          if [ -n "${PACKSLIP_VERSION}" ]; then
+            echo "::warning::packslip-path is set; ignoring packslip-version ${PACKSLIP_VERSION}"
+          fi
+          case "$PACKSLIP_PATH" in
+            */*) bin="$PACKSLIP_PATH" ;;
+            *) bin="$(command -v "$PACKSLIP_PATH")" || { echo "packslip-path not found on PATH: $PACKSLIP_PATH" >&2; exit 1; } ;;
+          esac
+          [ -x "$bin" ] || { echo "packslip-path is not an executable file: $PACKSLIP_PATH" >&2; exit 1; }
+          cp "$bin" "$dir/packslip$exe"
         else
-          tar -xJf "$dir/$asset" -C "$dir" --strip-components=1
+          version="${PACKSLIP_VERSION:-$(sed -nE 's/^version *= *"([^"]+)".*/\1/p' "${GITHUB_ACTION_PATH}/Cargo.toml" | head -n1)}"
+          [ -n "$version" ] || { echo "could not read the packslip version from Cargo.toml" >&2; exit 1; }
+          case "$(uname -m)" in
+            x86_64|amd64) arch=x64 ;;
+            aarch64|arm64) arch=arm64 ;;
+            *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+          esac
+          if [ "$os" = windows ]; then ext=zip; else ext=tar.xz; fi
+          asset="packslip-v${version}-${os}-${arch}.${ext}"
+          if ! gh release download "v${version}" -R jdx/packslip -p "$asset" -D "$dir" --clobber; then
+            echo "could not download $asset from jdx/packslip v${version}" >&2
+            if [ "$os" = darwin ] && [ "$arch" = x64 ]; then
+              # Current macOS releases are arm64 only.
+              echo "there is no macOS x64 release: build the CLI (cargo install packslip --version ${version} --locked --root \"\$RUNNER_TEMP/packslip\") and pass packslip-path" >&2
+            fi
+            exit 1
+          fi
+          # The archive was built by jdx/packslip's release workflow; check that before running it.
+          gh attestation verify "$dir/$asset" -R jdx/packslip
+          if [ "$ext" = zip ]; then
+            # -j drops the archive's directory so the executable lands in $dir.
+            (cd "$dir" && unzip -ojq "$asset")
+          else
+            tar -xJf "$dir/$asset" -C "$dir" --strip-components=1
+          fi
         fi
         echo "$dir" >> "$GITHUB_PATH"
-        "$dir/packslip" version
+        "$dir/packslip$exe" version
 
     - name: Collect artifacts
       id: files

--- a/content/docs/publishing.md
+++ b/content/docs/publishing.md
@@ -45,6 +45,8 @@ The action and CLI share a version: `@v0` follows CLI 0.x releases, and
 `@v0.2.0` pins both to 0.2.0. By default, the action installs the CLI
 version from its own commit's `Cargo.toml`. Set `packslip-version` to
 explicitly override that selection.
+`packslip-path` runs a CLI the job already has instead of downloading
+one; see [Build the CLI on the runner](#build-the-cli-on-the-runner).
 
 ## Add resources and requirements
 
@@ -86,6 +88,56 @@ in the filename: `tools/mytool` becomes `packslip.tools-mytool.sigstore.json`.
 The signer is still pinned to the repository. Consumers match the signed
 `project` field, not the bundle filename.
 
+## Build the CLI on the runner
+
+The action downloads the release archive for the runner's platform. Where
+that archive does not exist or cannot be used, `packslip-path` points the
+action at an executable the job already has: a path, or a name to look up
+on PATH. The action runs it as `packslip` for the rest of the steps and
+skips the download.
+
+macOS releases are arm64 only, so an x64 macOS job builds the CLI with
+cargo first:
+
+```yaml
+jobs:
+  release:
+    runs-on: macos-15-intel
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      # Build the archives and create the release before these steps.
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo install packslip --version 0.2.0 --locked --root "$RUNNER_TEMP/packslip"
+      - uses: jdx/packslip@v0.2.0
+        with:
+          packslip-path: ${{ runner.temp }}/packslip/bin/packslip
+          artifacts: dist/*.tar.xz
+          bin: mytool
+```
+
+Build on the runner that will run the binary; the action executes it
+rather than cross-compiling for anything. Install the version the action
+ref pins, since the action and CLI are released together, and prefer
+`--locked` so the build uses the dependency versions that release was
+tested with. The same approach covers a platform packslip does not ship,
+a self-hosted or network-restricted runner, and a job that would rather
+build from source than download.
+
+A matrix that needs this on only some runners can leave the input empty
+elsewhere; an empty `packslip-path` downloads as usual:
+
+```yaml
+packslip-path: ${{ runner.os == 'macOS' && runner.arch == 'X64' && format('{0}/packslip/bin/packslip', runner.temp) || '' }}
+```
+
+`packslip-path` takes precedence over `packslip-version`, which the action
+warns about when both are set. A downloaded archive is checked against
+jdx/packslip's build provenance before it runs; a binary supplied this way
+is not checked at all, so the job vouches for where it came from.
+
 ## Action inputs
 
 | Input | Purpose and default |
@@ -106,6 +158,7 @@ The signer is still pinned to the repository. Consumers match the signed
 | `out` | Bundle output directory; defaults to `packslip`. |
 | `upload` | Defaults to `true`. Set to `false` to keep the bundle local. |
 | `packslip-version` | CLI version; defaults to the version in the action's `Cargo.toml`. |
+| `packslip-path` | An existing packslip executable to run instead of downloading a release: a path, or a name on PATH. Takes precedence over `packslip-version`. |
 | `token` | Download/upload token; defaults to `github.token`. |
 
 The provenance step covers files matched by `artifacts`. Files supplied


### PR DESCRIPTION
The action always downloaded a packslip release archive for the runner's
platform. After #54 macOS releases are arm64 only, so an x64 macOS job has
no archive it can run — and the same holds for a platform packslip does
not ship, a self-hosted or network-restricted runner, or a job that would
rather build from source than download.

`packslip-path` takes an executable that is already on the runner: a path,
or a name to look up on PATH. It is copied into the temp bin directory as
`packslip`, so the create/verify steps run it exactly as before whatever
it is called locally, and the download and its `gh attestation verify` are
skipped. It takes precedence over `packslip-version`, warning when both
are set, so a matrix can select a built CLI on one runner and the download
on the rest.

```yaml
runs-on: macos-15-intel
steps:
  - uses: dtolnay/rust-toolchain@stable
  - run: cargo install packslip --version 0.2.0 --locked --root "$RUNNER_TEMP/packslip"
  - uses: jdx/packslip@v0.2.0
    with:
      packslip-path: ${{ runner.temp }}/packslip/bin/packslip
      artifacts: dist/*.tar.xz
      bin: mytool
```

A binary the action did not download is not checked in any way; the job
vouches for where it came from. The README and
[Publish with GitHub Actions](content/docs/publishing.md) both say so,
alongside the cargo build, the input table entry, and the matrix
expression for a mixed fleet. A download that fails now reports the asset
it wanted, and on macOS x64 points at building the CLI instead of leaving
a bare `gh` 404.

Also fixes an existing bug on Windows: the zip was unpacked without
junking its paths, leaving `packslip.exe` in a subdirectory of the one
added to PATH. That matters more now that #54 ships a windows-arm64
archive too.

Tested by running the install step's script directly with a stub binary:
absolute path, PATH lookup, the both-inputs warning, a name that is not
found, and a file that is not executable. `mise run docs:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which packslip binary runs in release workflows; caller-supplied CLIs bypass download provenance checks, though default download behavior still verifies attestations.
> 
> **Overview**
> Adds **`packslip-path`** so workflows can run a packslip binary already on the runner (path or PATH name) instead of downloading a release. The install step copies it to the temp bin dir as `packslip`, skips `gh release download` and **`gh attestation verify`**, and emits a warning when **`packslip-version`** is also set. Download failures on **macOS x64** now point users at building via `cargo install` and `packslip-path`.
> 
> Also fixes **Windows** installs by unpacking release zips with **`unzip -ojq`** so `packslip.exe` lands on PATH, and invokes **`packslip$exe`** for the version smoke check. README and publishing docs cover BYO CLI, matrix conditionals, and the trust model (job vouches for supplied binaries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9430edc4afa9a0e3fa946a93158fb7430b673e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->