### PR TITLE
ci: use the runner's Rust toolchain instead of installing stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      # The runner image ships a stable toolchain with rustfmt, but not clippy.
-      - run: rustup component add clippy
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           cache: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
+      # The runner image ships a stable toolchain with rustfmt, but not clippy.
+      - run: rustup component add clippy
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           cache: false
@@ -63,7 +62,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --release
       - name: Keyless, with this job's identity

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -26,10 +26,11 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           cache: false
+      # `mise run render` builds the CLI to regenerate the docs below.
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - id: release-plz
         uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
         with:
@@ -71,7 +72,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
       - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: crates-io-auth
       - uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,9 +77,9 @@ jobs:
         with:
           p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
           p12-password: ${{ secrets.CERTIFICATES_P12_PASS }}
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
+      # The runner image ships a stable toolchain; only the cross-compiled
+      # targets have to be added to it.
+      - run: rustup target add ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.target }}


### PR DESCRIPTION
Every GitHub runner image already ships a stable Rust toolchain, so `dtolnay/rust-toolchain@stable` was reinstalling what was already there. All five uses are gone; one of them was doing something the images don't cover, so it got a one-line replacement:

- **release.yml (build)** — the musl targets aren't preinstalled, so `rustup target add ${{ matrix.target }}` stands in for the `targets:` input. It's a no-op on the three native targets.

The other four needed nothing: the image's `install-rust.sh` already runs `rustup component add rustfmt clippy`, so ci.yml's `components:` input was a no-op too.

Also added `Swatinem/rust-cache` to the release-plz PR job, which was the one non-release job building Rust without it — `mise run render` compiles the CLI to regenerate the docs it squashes into the release PR.

### Trade-off

The preinstalled toolchain is what CI gets now, and it lags real stable and isn't uniform across images — 1.98.0 on Ubuntu and Windows, 1.97.1 on macOS. The `rust-version = "1.95"` MSRV clears both, but the release matrix now compiles with slightly different compilers per platform, and `Swatinem/rust-cache` keys on the rustc version, so caches re-warm once. A `rust-toolchain.toml` with a pinned channel would restore an exact floor without a third-party action, if that's worth it later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes with no application code; main risk is CI/release builds using slightly different preinstalled rustc versions per OS until caches warm.
> 
> **Overview**
> **CI and release workflows no longer install stable Rust via `dtolnay/rust-toolchain`**, relying on the toolchain already on GitHub-hosted runners instead.
> 
> In **`ci.yml`**, the `test` and `signing` jobs drop the rust-toolchain step; `test` still runs `cargo fmt`, `clippy`, build, and tests after `mise-action` and `Swatinem/rust-cache`. In **`release-plz.yml`**, both `release-pr` and `release` jobs drop rust-toolchain; the **`release-pr`** job adds **`Swatinem/rust-cache`** (pinned) before `release-plz`, with a note that `mise run render` compiles the CLI when squashing generated docs into the release PR. In **`release.yml`**, the matrix build replaces rust-toolchain’s `targets:` input with **`rustup target add ${{ matrix.target }}`** so cross targets (e.g. musl) are added to the image’s stable toolchain.
> 
> **Trade-off:** compiler versions can differ slightly by runner image until caches re-key on rustc version; MSRV in the crate still bounds supported versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8be8d991d2ba5fa9b0ab46e08829425610251d24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
