### PR TITLE
feat: make the CLI, generator, and signing path optional features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
       - run: cargo clippy --all-features --all-targets -- -D warnings
       - run: cargo build --all-features
       - run: cargo test --all-features
+      # A consumer that only verifies takes the crate with no default
+      # features; keep that build compiling and its tests passing.
+      - run: cargo clippy --no-default-features --all-targets -- -D warnings
+      - run: cargo test --no-default-features
       - run: mise run render
       - run: usage lint packslip.usage.kdl
       - run: mise run docs:check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,42 +13,74 @@ categories = ["command-line-utilities", "cryptography"]
 # Keep action.yml in the package so action-only changes trigger a shared release.
 exclude = ["content/", "data/", "layouts/", "static/", "hugo.toml", ".github/", "CHANGELOG.md", "RELEASING.md", "cliff.toml", "release-plz.toml"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [[bin]]
 name = "packslip"
 path = "src/main.rs"
+required-features = ["cli"]
+
+[[test]]
+name = "cli"
+path = "tests/cli.rs"
+required-features = ["cli"]
+
+# A consumer that only verifies a packslip and reads what it says takes the
+# crate with `default-features = false`: the schema, the verifier, and the
+# selection rules, without the archive readers, the executable decoder, the
+# signing path, or the CLI. Everything is on by default, so the binary and
+# existing dependents are unaffected.
+[features]
+default = ["cli"]
+# The `packslip` binary: argument parsing and error reporting.
+cli = ["create", "manifest", "schema", "dep:color-eyre", "dep:eyre", "dep:usage_rs"]
+# `packslip create`: build a statement from a set of built artifacts.
+create = ["archive", "linkage", "sign"]
+# Read a packslip.toml.
+manifest = ["dep:toml"]
+# Decode tar and zip archives to resolve the paths of declared executables.
+archive = ["dep:bzip2", "dep:flate2", "dep:lzma-rs", "dep:ruzstd", "dep:tar", "dep:zip"]
+# Derive `requires.libs` by reading ELF, Mach-O, and PE executables.
+linkage = ["archive", "dep:goblin"]
+# Sign statements, keylessly through Fulcio or with a minisign key.
+# Verification never needs this.
+sign = ["dep:getrandom", "dep:sigstore-oidc", "dep:sigstore-sign"]
+# JSON Schema for the statement types.
+schema = ["dep:schemars"]
 
 [dependencies]
 base64 = "0.22"
 blake2 = "0.10"
-bzip2 = "0.6"
-color-eyre = "0.6"
+bzip2 = { version = "0.6", optional = true }
+color-eyre = { version = "0.6", optional = true }
 ed25519-dalek = "2"
-eyre = "0.6"
-flate2 = "1"
-getrandom = "0.3"
-goblin = "0.10"
+eyre = { version = "0.6", optional = true }
+flate2 = { version = "1", optional = true }
+getrandom = { version = "0.3", optional = true }
+goblin = { version = "0.10", optional = true }
 jiff = "0.2"
-lzma-rs = "0.3"
-schemars = "1"
+lzma-rs = { version = "0.3", optional = true }
+schemars = { version = "1", optional = true }
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 sigstore-bundle = { version = "0.11", default-features = false, features = ["rustls"] }
-sigstore-oidc = { version = "0.11", default-features = false, features = ["rustls"] }
+sigstore-oidc = { version = "0.11", default-features = false, features = ["rustls"], optional = true }
 sigstore-rekor = { version = "0.11", default-features = false, features = ["rustls"] }
-sigstore-sign = { version = "0.11", default-features = false, features = ["rustls"] }
+sigstore-sign = { version = "0.11", default-features = false, features = ["rustls"], optional = true }
 sigstore-trust-root = { version = "0.11", default-features = false, features = ["rustls"] }
 sigstore-types = "0.11"
-ruzstd = "0.9"
+ruzstd = { version = "0.9", optional = true }
 sigstore-verify = { version = "0.11", default-features = false, features = ["rustls"] }
-tar = "0.4"
+tar = { version = "0.4", optional = true }
 thiserror = "2"
 tokio = { version = "1", features = ["rt"] }
-toml = "1"
-zip = { version = "8", default-features = false, features = ["deflate"] }
+toml = { version = "1", optional = true }
+zip = { version = "8", default-features = false, features = ["deflate"], optional = true }
 # usage-rs derives scan this table line by line for the alias below.
-usage_rs = { package = "usage-rs", version = "6", features = ["completions"] }
+usage_rs = { package = "usage-rs", version = "6", features = ["completions"], optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/content/docs/verifying.md
+++ b/content/docs/verifying.md
@@ -113,6 +113,33 @@ selection, and remembered policy. Implement the full
    Select resources for the chosen artifact and executable, and follow
    the execution rules for generated resources.
 
+### Take the crate as a library
+
+The `packslip` crate holds the schema, the verifier, and the selection
+rules as well as the CLI and the generator. A consumer that only verifies
+takes it without the parts it will not call:
+
+```sh
+cargo add packslip --no-default-features
+```
+
+That leaves the statement types, `verify`, `verify_release_list`,
+`select_artifact`, and `select_resources`, and drops the archive readers,
+the executable decoder that derives `requires.libs`, the signing path, the
+JSON Schema generator, and the CLI: about seventy fewer crates in the
+dependency graph. The features are additive and all on by default, so the
+binary and any dependent that says nothing is unaffected:
+
+| Feature | Adds |
+| --- | --- |
+| `cli` (default) | The `packslip` binary; implies the rest. |
+| `create` | Build a statement from built artifacts; implies `archive`, `linkage`, and `sign`. |
+| `archive` | Read tar and zip archives to resolve declared executable paths. |
+| `linkage` | Derive `requires.libs` from ELF, Mach-O, and PE executables. |
+| `sign` | Sign statements, keylessly through Fulcio or with a minisign key. |
+| `manifest` | Read a `packslip.toml`. |
+| `schema` | `Statement::schema()` and `ReleaseListStatement::schema()`. |
+
 A lockfile can carry a project's signer commitment alongside artifact
 URLs and digests so another machine can enforce it on its first install.
 Local state can separately remember signer history and release-list

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,20 +9,31 @@
 //! Ed25519 key, and either way logged to Rekor ([`sigstore`]). The same
 //! shape carries a project's release list. This crate holds the schema,
 //! the verifier, and the generator. See <https://packslip.dev/release/v1/>.
+//!
+//! Everything is on by default. A consumer that only verifies takes the
+//! crate with `default-features = false`, which keeps [`model`], [`verify`],
+//! and [`sigstore`] and drops the archive readers, the executable decoder,
+//! the signing path, and the CLI.
 
 #![forbid(unsafe_code)]
 
+#[cfg(feature = "archive")]
 pub mod archive;
+#[cfg(feature = "cli")]
 pub mod cli;
+#[cfg(feature = "create")]
 pub mod create;
 pub mod dsse;
+#[cfg(feature = "linkage")]
 pub mod linkage;
+#[cfg(feature = "manifest")]
 pub mod manifest;
 pub mod minisign;
 pub mod model;
 pub mod sigstore;
 pub mod verify;
 
+#[cfg(feature = "manifest")]
 pub use manifest::Manifest;
 pub use model::{
     Artifact, Attestor, Bin, Evidence, Host, Identity, Predicate, ReleaseList,
@@ -30,7 +41,9 @@ pub use model::{
     ResourceSource, Scheme, Selection, Source, Statement, Subject, command_name, github_list_path,
     list_url, select_artifact, select_resources, tag_version,
 };
-pub use sigstore::{Policy, Signer, Trust};
+#[cfg(feature = "sign")]
+pub use sigstore::Signer;
+pub use sigstore::{Policy, Trust};
 pub use verify::{Options, Verified, VerifiedList, verify, verify_release_list};
 
 /// The sha256 of a file, lowercase hex, and its size.

--- a/src/minisign.rs
+++ b/src/minisign.rs
@@ -143,6 +143,7 @@ impl PublicKey {
 
 impl SecretKey {
     /// A fresh random key.
+    #[cfg(feature = "sign")]
     pub fn generate() -> SecretKey {
         let mut seed = [0u8; 32];
         getrandom::fill(&mut seed).expect("the OS provides randomness");

--- a/src/model.rs
+++ b/src/model.rs
@@ -2,6 +2,7 @@
 //! release shipped (`release/v1`) and which releases a project has
 //! (`releases/v1`). See `docs/spec/packslip.md`.
 
+#[cfg(feature = "schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -17,7 +18,8 @@ pub const RELEASES_PREDICATE_TYPE: &str = "https://packslip.dev/releases/v1";
 pub type Extensions = serde_json::Map<String, serde_json::Value>;
 
 /// An in-toto statement carrying predicate `P`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct Envelope<P> {
     #[serde(rename = "_type")]
     pub kind: String,
@@ -34,21 +36,23 @@ pub type Statement = Envelope<Predicate>;
 /// A project's recent releases, for discovery.
 pub type ReleaseListStatement = Envelope<ReleaseList>;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct Subject {
     pub name: String,
     pub digest: Digest,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct Digest {
     /// Lowercase hex.
-    #[schemars(regex(pattern = r"^[0-9a-f]{64}$"))]
+    #[cfg_attr(feature = "schema", schemars(regex(pattern = r"^[0-9a-f]{64}$")))]
     pub sha256: String,
     /// Lowercase hex, for consumers that want it (electron-updater,
     /// Balrog, Scoop).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(regex(pattern = r"^[0-9a-f]{128}$"))]
+    #[cfg_attr(feature = "schema", schemars(regex(pattern = r"^[0-9a-f]{128}$")))]
     pub sha512: Option<String>,
 }
 
@@ -125,7 +129,8 @@ pub fn valid_token(value: &str) -> bool {
         })
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct Predicate {
     /// The project's name: a host path such as `github.com/jdx/mise` or
     /// `mise.jdx.dev`. The host is where a
@@ -137,10 +142,10 @@ pub struct Predicate {
     /// part, if any, marks a prerelease, and the first identifier of that
     /// part names the channel: see [`channel`]. On a forge, the release
     /// tag names this version: see [`tag_version`].
-    #[schemars(regex(pattern = SEMVER_PATTERN))]
+    #[cfg_attr(feature = "schema", schemars(regex(pattern = SEMVER_PATTERN)))]
     pub version: String,
     /// RFC 3339 UTC.
-    #[schemars(extend("format" = "date-time"))]
+    #[cfg_attr(feature = "schema", schemars(extend("format" = "date-time")))]
     pub published_at: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<Source>,
@@ -167,7 +172,8 @@ pub struct Predicate {
 }
 
 /// Who signed the claim.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 pub enum Attestor {
     /// The project's own publisher.
@@ -457,7 +463,8 @@ pub fn select_artifact<'a>(
 /// Documented kinds: `pkgbuild-checksums`, `checksum-file-over-tls`,
 /// `apt-release-gpg`, `vendor-signature`, `vendor-packslip`,
 /// `github-attestation`, `provenance-verified`, `scan`, `none`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct Evidence {
     pub kind: String,
     /// A key id, URL, or note that lets a reader check the claim: the
@@ -466,7 +473,8 @@ pub struct Evidence {
     pub detail: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct Source {
     pub repo: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -475,31 +483,32 @@ pub struct Source {
     pub tag: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct Artifact {
     pub name: String,
     /// `linux`, `darwin`, `windows`, `freebsd`, `netbsd`, `openbsd`,
     /// `illumos`, `android`, `ios`. Absent when the artifact runs on any
     /// OS.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(regex(pattern = TOKEN_PATTERN))]
+    #[cfg_attr(feature = "schema", schemars(regex(pattern = TOKEN_PATTERN)))]
     pub os: Option<String>,
     /// `x86_64`, `aarch64`, `armv7`, `armv6`, `riscv64`, `i686`,
     /// `powerpc64le`, `s390x`, `loongarch64`. Absent when the artifact
     /// runs on any architecture.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(regex(pattern = TOKEN_PATTERN))]
+    #[cfg_attr(feature = "schema", schemars(regex(pattern = TOKEN_PATTERN)))]
     pub arch: Option<String>,
     /// `gnu` or `musl`, for a Linux build. Absent when the artifact does
     /// not depend on one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(regex(pattern = TOKEN_PATTERN))]
+    #[cfg_attr(feature = "schema", schemars(regex(pattern = TOKEN_PATTERN)))]
     pub libc: Option<String>,
     /// Tells apart builds that share os, arch, and libc: `fips`,
     /// `baseline`, `debug`, `installer`, `source`. A consumer selects only
     /// artifacts without a variant unless asked for one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(regex(pattern = TOKEN_PATTERN))]
+    #[cfg_attr(feature = "schema", schemars(regex(pattern = TOKEN_PATTERN)))]
     pub variant: Option<String>,
     pub size: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -511,7 +520,7 @@ pub struct Artifact {
     /// artifacts that differ only in format carry the same build, and a
     /// consumer takes whichever it prefers.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(regex(pattern = TOKEN_PATTERN))]
+    #[cfg_attr(feature = "schema", schemars(regex(pattern = TOKEN_PATTERN)))]
     pub format: Option<String>,
     /// Executables inside the artifact, as paths relative to the archive
     /// root, or the artifact's own name (minus any compression suffix)
@@ -533,7 +542,8 @@ pub struct Artifact {
 
 /// An executable inside an artifact. Serialises as the bare path when the
 /// PATH name is the file's own name, else as `{ "path", "name" }`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(from = "BinRepr", into = "BinRepr")]
 pub struct Bin {
     /// Path inside the archive, relative to its root.
@@ -580,7 +590,8 @@ pub fn command_name(name: &str) -> &str {
     }
 }
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(untagged)]
 enum BinRepr {
     Path(String),
@@ -614,7 +625,8 @@ impl From<Bin> for BinRepr {
 /// defines, so a consumer can check before installing. Nothing here names
 /// another project or where to get it; see the specification's Host
 /// requirements section.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct Requires {
     /// Minimum OS version, in the OS's own terms: `12` for macOS Monterey,
     /// `10.0.17763` for Windows.
@@ -672,7 +684,8 @@ impl Requires {
 }
 
 /// A command an executable needs on PATH.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct RequiredBin {
     /// The name as the executable invokes it, bare: `java`, `python3`,
     /// `git`. No directory and no `.exe`.
@@ -737,7 +750,8 @@ fn valid_min_version(min: &str) -> bool {
 /// `repo`, and `exec` says where it comes from. Documented kinds:
 /// `completion`, `man`, `cli-spec`, `skill`, `desktop`, `icon`, `app`,
 /// `sbom`. Consumers ignore kinds they do not know.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct Resource {
     pub kind: String,
     /// Exact artifact name. More specific than any platform-only scope.
@@ -746,15 +760,15 @@ pub struct Resource {
     /// Limits the entry to artifacts of this `os`, when layouts differ by
     /// platform. Absent means any artifact. See [`resource_fits`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(regex(pattern = TOKEN_PATTERN))]
+    #[cfg_attr(feature = "schema", schemars(regex(pattern = TOKEN_PATTERN)))]
     pub os: Option<String>,
     /// Likewise for `arch`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(regex(pattern = TOKEN_PATTERN))]
+    #[cfg_attr(feature = "schema", schemars(regex(pattern = TOKEN_PATTERN)))]
     pub arch: Option<String>,
     /// Likewise for `libc`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(regex(pattern = TOKEN_PATTERN))]
+    #[cfg_attr(feature = "schema", schemars(regex(pattern = TOKEN_PATTERN)))]
     pub libc: Option<String>,
     /// For `completion` with a static source: the shell, such as `bash`,
     /// `zsh`, `fish`, `powershell`, `nushell`, `elvish`.
@@ -982,7 +996,8 @@ fn valid_relative_path(path: &str) -> bool {
 
 /// How the document is signed, so a consumer can check what it pinned
 /// against what it received.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct Identity {
     pub scheme: Scheme,
     /// For `sigstore-oidc`, the certificate's subject identity: the
@@ -995,7 +1010,8 @@ pub struct Identity {
     pub issuer: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 pub enum Scheme {
     /// A sigstore bundle signed keylessly with a workload or human OIDC
@@ -1018,7 +1034,8 @@ impl std::fmt::Display for Scheme {
 /// The `releases/v1` predicate: which releases a project has, so a
 /// consumer can find them without a registry, and cannot be shown a stale
 /// or truncated view without noticing.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct ReleaseList {
     pub project: String,
     /// When the list was produced, RFC 3339 UTC.
@@ -1032,7 +1049,7 @@ pub struct ReleaseList {
     /// The vendor's recommended default: an exact version in `releases`.
     /// Consumers still apply all eligibility checks before selecting it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(regex(pattern = SEMVER_PATTERN))]
+    #[cfg_attr(feature = "schema", schemars(regex(pattern = SEMVER_PATTERN)))]
     pub latest: Option<String>,
     /// In any order; consumers rank by semver precedence.
     pub releases: Vec<ReleaseRef>,
@@ -1042,16 +1059,17 @@ pub struct ReleaseList {
     pub extensions: Extensions,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct ReleaseRef {
-    #[schemars(regex(pattern = SEMVER_PATTERN))]
+    #[cfg_attr(feature = "schema", schemars(regex(pattern = SEMVER_PATTERN)))]
     pub version: String,
     /// The vendor's own spelling of the release, copied from the packslip's
     /// `source.tag`, so a consumer can accept a request in either form.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tag: Option<String>,
     /// RFC 3339 UTC, copied from the release's packslip.
-    #[schemars(extend("format" = "date-time"))]
+    #[cfg_attr(feature = "schema", schemars(extend("format" = "date-time")))]
     pub published_at: String,
     /// URL of the release's `packslip.sigstore.json`. The statement's
     /// subject of the same name carries that file's digest.
@@ -1077,7 +1095,8 @@ pub struct ReleaseRef {
     pub evidence: Vec<Evidence>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 pub enum ReleaseStatus {
     Yanked,
@@ -1613,6 +1632,7 @@ impl Statement {
     }
 
     /// The JSON schema for the document.
+    #[cfg(feature = "schema")]
     pub fn schema() -> serde_json::Value {
         serde_json::to_value(schemars::schema_for!(Statement)).expect("schema serialises")
     }
@@ -1668,6 +1688,7 @@ impl ReleaseListStatement {
     }
 
     /// The JSON schema for the document.
+    #[cfg(feature = "schema")]
     pub fn schema() -> serde_json::Value {
         serde_json::to_value(schemars::schema_for!(ReleaseListStatement))
             .expect("schema serialises")
@@ -2436,8 +2457,11 @@ mod tests {
         let mut bad = sample_list();
         bad.predicate.releases.clear();
         assert_eq!(bad.validate(), Err(InvalidDocument::NoReleases));
-        let schema = ReleaseListStatement::schema();
-        assert!(schema["properties"]["predicate"].is_object());
+        #[cfg(feature = "schema")]
+        {
+            let schema = ReleaseListStatement::schema();
+            assert!(schema["properties"]["predicate"].is_object());
+        }
     }
 
     #[test]
@@ -3235,6 +3259,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "schema")]
     fn schema_has_the_required_fields() {
         let schema = Statement::schema();
         let required = schema["required"].as_array().unwrap();

--- a/src/sigstore.rs
+++ b/src/sigstore.rs
@@ -8,20 +8,26 @@ use std::borrow::Cow;
 
 use base64::Engine as _;
 use base64::engine::general_purpose::{STANDARD as BASE64, URL_SAFE_NO_PAD};
+#[cfg(feature = "sign")]
 use ed25519_dalek::Signer as _;
 use sha2::Digest as _;
+#[cfg(feature = "sign")]
 use sigstore_bundle::{BundleV03, TlogEntryBuilder, VerificationMaterialV03};
+#[cfg(feature = "sign")]
 use sigstore_oidc::IdentityToken;
+#[cfg(feature = "sign")]
 use sigstore_rekor::{DsseEntry, RekorClient};
+#[cfg(feature = "sign")]
 use sigstore_sign::SigningContext;
 use sigstore_trust_root::{SIGSTORE_PRODUCTION_TRUSTED_ROOT, TrustedRoot};
-use sigstore_types::{
-    Artifact, Bundle, DerPublicKey, DsseEnvelope, DsseSignature, KeyId, PayloadBytes, Sha256Hash,
-    SignatureBytes, SignatureContent,
-};
+use sigstore_types::{Artifact, Bundle, DerPublicKey, Sha256Hash, SignatureContent};
+#[cfg(feature = "sign")]
+use sigstore_types::{DsseEnvelope, DsseSignature, KeyId, PayloadBytes, SignatureBytes};
 use sigstore_verify::VerificationPolicy;
 
-use crate::minisign::{PublicKey, SecretKey, key_id_hex};
+#[cfg(feature = "sign")]
+use crate::minisign::SecretKey;
+use crate::minisign::{PublicKey, key_id_hex};
 
 pub const GITHUB_ISSUER: &str = "https://token.actions.githubusercontent.com";
 pub const GITLAB_ISSUER: &str = "https://gitlab.com";
@@ -71,6 +77,7 @@ pub enum Error {
     NoPolicy(String),
 }
 
+#[cfg(feature = "sign")]
 fn runtime() -> Result<tokio::runtime::Runtime, Error> {
     tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -80,6 +87,7 @@ fn runtime() -> Result<tokio::runtime::Runtime, Error> {
 
 /// An OIDC identity ready to sign with, and what Fulcio will put in the
 /// certificate for it.
+#[cfg(feature = "sign")]
 pub struct OidcIdentity {
     token: IdentityToken,
     /// The certificate subject identity: a workflow URI for CI, an email
@@ -88,6 +96,7 @@ pub struct OidcIdentity {
     pub issuer: String,
 }
 
+#[cfg(feature = "sign")]
 impl std::fmt::Debug for OidcIdentity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OidcIdentity")
@@ -97,6 +106,7 @@ impl std::fmt::Debug for OidcIdentity {
     }
 }
 
+#[cfg(feature = "sign")]
 impl OidcIdentity {
     fn from_token(token: IdentityToken) -> Result<OidcIdentity, Error> {
         let identity = certificate_identity(token.raw())?;
@@ -110,6 +120,7 @@ impl OidcIdentity {
 
 /// The identity from `SIGSTORE_ID_TOKEN`, or the ambient CI credential
 /// (GitHub Actions, GitLab CI, Buildkite, and the others sigstore knows).
+#[cfg(feature = "sign")]
 pub fn ambient_identity() -> Result<OidcIdentity, Error> {
     if let Ok(raw) = std::env::var(TOKEN_ENV)
         && !raw.trim().is_empty()
@@ -163,6 +174,7 @@ pub fn certificate_identity(jwt: &str) -> Result<String, Error> {
 }
 
 /// Who signs.
+#[cfg(feature = "sign")]
 pub enum Signer {
     /// Keyless, with an OIDC identity.
     Oidc(OidcIdentity),
@@ -172,6 +184,7 @@ pub enum Signer {
     Key { key: SecretKey, log: bool },
 }
 
+#[cfg(feature = "sign")]
 impl Signer {
     /// The `identity` block a document signed by this signer declares.
     pub fn identity(&self) -> crate::model::Identity {
@@ -201,6 +214,7 @@ pub fn spki_der(key: &PublicKey) -> Vec<u8> {
     der
 }
 
+#[cfg(feature = "sign")]
 fn spki_pem(key: &PublicKey) -> String {
     let b64 = BASE64.encode(spki_der(key));
     let mut pem = String::from("-----BEGIN PUBLIC KEY-----\n");
@@ -220,6 +234,7 @@ pub fn key_hint(key: &PublicKey) -> String {
 
 /// Sign `statement` (the payload bytes) into a sigstore bundle, returned
 /// as JSON.
+#[cfg(feature = "sign")]
 pub fn sign(signer: Signer, statement: &[u8]) -> Result<String, Error> {
     let rt = runtime()?;
     let bundle = match signer {
@@ -575,6 +590,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "sign")]
     fn key_signed_bundles_round_trip_unlogged() {
         let root = trusted_root(None).unwrap();
         let key = SecretKey::from_seed([7u8; 32]);
@@ -618,6 +634,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "sign")]
     fn spki_and_hint_are_stable() {
         let key = SecretKey::from_seed([1u8; 32]).public_key();
         let der = spki_der(&key);


### PR DESCRIPTION
## Summary

The crate is one package: the schema, the verifier, the generator, and the binary. A consumer that only verifies a packslip compiles all of it — and pays for the archive readers, goblin's ELF/Mach-O decoder, the Fulcio and OIDC signing path, schemars, toml, and usage-rs on the way to calling `verify`.

This makes those parts additive features, **all on by default**. The binary and every existing dependent are unaffected; a verifying consumer takes the crate with `default-features = false`.

```sh
cargo add packslip --no-default-features
```

That leaves the statement types, `verify`, `verify_release_list`, `select_artifact`, and `select_resources`.

| Feature | Adds |
| --- | --- |
| `cli` (default) | The `packslip` binary; implies the rest. |
| `create` | Build a statement from built artifacts; implies `archive`, `linkage`, `sign`. |
| `archive` | Read tar and zip archives to resolve declared executable paths. |
| `linkage` | Derive `requires.libs` from ELF, Mach-O, and PE executables. |
| `sign` | Sign statements, keylessly through Fulcio or with a minisign key. |
| `manifest` | Read a `packslip.toml`. |
| `schema` | `Statement::schema()` and `ReleaseListStatement::schema()`. |

## What it saves

**73 of the 232 crates** in the dependency graph, measured with `cargo tree --edges normal`:

> addr2line adler2 ambient-id anyhow astral-reqwest-middleware async-compression async-trait backtrace bumpalo byteorder bzip2 color-eyre color-spantrace compression-codecs compression-core crc crc32fast crc-catalog dyn-clone equivalent eyre filetime flate2 fnv futures-sink gimli goblin h2 hashbrown indenter indexmap lazy_static libbz2-rs-sys lzma-rs miniz_oxide object owo-colors plain ref-cast ref-cast-impl rustc-demangle ruzstd schemars schemars_derive scroll scroll_derive secrecy serde_derive_internals serde_spanned sharded-slab sigstore-fulcio sigstore-oidc sigstore-sign simd-adler32 tar thread_local tokio-util toml toml_datetime toml_parser toml_writer tracing-error tracing-subscriber twox-hash typed-path usage-argv usage-derive usage-rs winnow xattr zip zlib-rs zopfli

The concrete case is mise's `packslip:` backend ([jdx/mise#12778](https://github.com/jdx/mise/pull/12778), the base of a 12-PR stack — the other eleven PRs add nothing to `Cargo.lock`). That PR adds 13 crates to mise's lockfile; **12 of them go**, leaving only `packslip` itself:

`goblin`, `plain`, `scroll`, `scroll_derive`, `lzma-rs`, `crc`, `crc-catalog`, `ruzstd`, `twox-hash`, `sigstore-sign`, `sigstore-fulcio`, `sigstore-oidc`.

Every one of those sits on a path mise never reaches: goblin decodes executables for `requires.libs` at create time, the sigstore trio talks to Fulcio, and the xz/zstd readers resolve paths inside archives that mise unpacks itself.

## Test plan

- [x] `cargo clippy --all-features --all-targets -- -D warnings`, `cargo build --all-features`, `cargo test --all-features` — unchanged, 59 tests pass
- [x] `cargo clippy --no-default-features --all-targets -- -D warnings` and `cargo test --no-default-features` — 30 tests pass. Both now run in CI.
- [x] Every feature builds on its own: `--no-default-features --features <f>` for each of `schema`, `sign`, `archive`, `linkage`, `manifest`, `create`, `cli`
- [x] `cargo fmt --all --check`, `mise run render` (no diff), `usage lint`, `mise run docs:check`
- [x] Compiled a scratch consumer against `default-features = false` using mise's exact API surface at the stack tip (`src/backend/packslip.rs` and `src/packslip.rs` on `codex/packslip-resource-lifecycle`) — nothing it calls is behind a feature

The mise side is one line, after the next packslip release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Feature gating changes the public API surface when features are disabled and could break dependents that relied on implicit full builds; default features preserve today’s behavior but misconfigured `Cargo.toml` in consumers could fail to compile until they enable needed features.
> 
> **Overview**
> **Adds additive Cargo features** so verify-only dependents can use `default-features = false` and avoid the CLI, archive/linkage readers, signing stack, TOML manifest, and JSON Schema generation—while **defaults stay `cli`**, so the binary and unchanged dependents behave as before.
> 
> The **`cli`** feature gates the binary and integration tests; **`create`**, **`archive`**, **`linkage`**, **`sign`**, **`manifest`**, and **`schema`** split optional deps and `#[cfg(feature = …)]` on modules, `Signer` re-exports, `schemars` derives, and signing APIs. Verification paths (`verify`, `model`, `Policy`/`Trust`) remain available without defaults.
> 
> **CI** now runs `cargo clippy` and `cargo test` with `--no-default-features`. **Docs** document `cargo add packslip --no-default-features` and the feature table; crate docs note the slim library surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dd21554106aae3d70859ce2bb7afbb92342f9c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable Cargo features for selectively enabling CLI, archive handling, creation, manifests, signing, linkage, and schema generation.
  - Libraries can now be consumed with default features disabled for a smaller verification-focused installation.
  - Default builds continue to include all features.

- **Documentation**
  - Added guidance describing feature usage and the capabilities provided by each option.
  - Configured generated documentation to include all features.

- **Tests**
  - Expanded CI validation to cover Clippy and builds without default features.
  - Added coverage for the feature-gated CLI build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->