### PR TITLE
fix(resources): an archive source never applies to a bare artifact

### DIFF
--- a/content/spec.md
+++ b/content/spec.md
@@ -372,7 +372,9 @@ source.
 After applying scope and specificity, consumers prefer sources in this order:
 
 - `archive`: a path inside the artifact the consumer selected, from the
-  true archive root. The artifact's digest already covers it.
+  true archive root. The artifact's digest already covers it. Only for an
+  artifact that has paths inside it, which a bare format does not; see
+  Scope and identity.
 - `asset`: a separate release file. It is listed in `subject` with its
   digest and the entry carries its download `url`, so it verifies exactly
   as an artifact does. A skill directory ships this way as an archive of
@@ -398,10 +400,20 @@ the same platform have different layouts or a resource belongs to one
 variant. That artifact must exist and match any platform scope on the
 entry. An artifact-specific entry outranks every platform-only entry for
 the same resource; among equally scoped entries the platform specificity
-and source ordering below apply. For example, a man page inside
-`tool-linux-x64.tar.xz` can name that artifact without claiming the bare
-`tool-linux-x64` executable holds a man page. A TOML manifest spells this
-as `artifact = "tool-linux-x64.tar.xz"` inside `[[resource]]`.
+and source ordering below apply. For example, a man page that a `fips`
+variant keeps at a different path from the ordinary `tool-linux-x64.tar.xz`
+can name each archive rather than claiming one layout for the platform. A
+TOML manifest spells this as `artifact = "tool-linux-x64.tar.xz"` inside
+`[[resource]]`.
+
+An `archive` entry never applies to an artifact whose `format` is bare:
+`raw`, `gz`, `xz`, `zst`, or `bz2`. Such an artifact is the executable
+itself, so it holds no path for the entry to name. A vendor that publishes
+`tool-linux-x64.tar.xz` beside a bare `tool-linux-x64` therefore needs no
+scope to keep an archive entry off the bare one; the entry's source
+already says which artifacts it can describe. This bears on the source and
+not on the resource, so the same man page may still reach a bare artifact
+through an `asset` or `repo` entry.
 
 Entries compete only with entries for the same thing. Two entries are for
 the same thing when they share a `kind` and an identity: `bin` and

--- a/docs/spec/packslip.md
+++ b/docs/spec/packslip.md
@@ -368,7 +368,9 @@ source.
 After applying scope and specificity, consumers prefer sources in this order:
 
 - `archive`: a path inside the artifact the consumer selected, from the
-  true archive root. The artifact's digest already covers it.
+  true archive root. The artifact's digest already covers it. Only for an
+  artifact that has paths inside it, which a bare format does not; see
+  Scope and identity.
 - `asset`: a separate release file. It is listed in `subject` with its
   digest and the entry carries its download `url`, so it verifies exactly
   as an artifact does. A skill directory ships this way as an archive of
@@ -394,10 +396,20 @@ the same platform have different layouts or a resource belongs to one
 variant. That artifact must exist and match any platform scope on the
 entry. An artifact-specific entry outranks every platform-only entry for
 the same resource; among equally scoped entries the platform specificity
-and source ordering below apply. For example, a man page inside
-`tool-linux-x64.tar.xz` can name that artifact without claiming the bare
-`tool-linux-x64` executable holds a man page. A TOML manifest spells this
-as `artifact = "tool-linux-x64.tar.xz"` inside `[[resource]]`.
+and source ordering below apply. For example, a man page that a `fips`
+variant keeps at a different path from the ordinary `tool-linux-x64.tar.xz`
+can name each archive rather than claiming one layout for the platform. A
+TOML manifest spells this as `artifact = "tool-linux-x64.tar.xz"` inside
+`[[resource]]`.
+
+An `archive` entry never applies to an artifact whose `format` is bare:
+`raw`, `gz`, `xz`, `zst`, or `bz2`. Such an artifact is the executable
+itself, so it holds no path for the entry to name. A vendor that publishes
+`tool-linux-x64.tar.xz` beside a bare `tool-linux-x64` therefore needs no
+scope to keep an archive entry off the bare one; the entry's source
+already says which artifacts it can describe. This bears on the source and
+not on the resource, so the same man page may still reach a bare artifact
+through an `asset` or `repo` entry.
 
 Entries compete only with entries for the same thing. Two entries are for
 the same thing when they share a `kind` and an identity: `bin` and

--- a/src/model.rs
+++ b/src/model.rs
@@ -291,15 +291,20 @@ pub fn normalize_version(text: &str) -> Option<String> {
 }
 
 /// Whether a resource applies to an artifact: each of the resource's
-/// `os`, `arch`, and `libc` is absent or equal to the artifact's, and
-/// an `artifact` selector names it. A
+/// `os`, `arch`, and `libc` is absent or equal to the artifact's, an
+/// `artifact` selector names it, and an `archive` source is not being
+/// claimed of a bare-format artifact, which is the executable itself and
+/// holds no paths to name. A
 /// consumer choosing among entries for the same thing takes the one
 /// naming the most of those fields; [`select_resources`] does that.
 pub fn resource_fits(resource: &Resource, artifact: &Artifact) -> bool {
-    resource
-        .artifact
-        .as_ref()
-        .is_none_or(|name| name == &artifact.name)
+    let inside_a_bare_artifact =
+        resource.archive.is_some() && artifact.format.as_deref().is_some_and(is_bare_format);
+    !inside_a_bare_artifact
+        && resource
+            .artifact
+            .as_ref()
+            .is_none_or(|name| name == &artifact.name)
         && [
             (&resource.os, &artifact.os),
             (&resource.arch, &artifact.arch),
@@ -1188,6 +1193,10 @@ pub enum InvalidDocument {
     ResourceKind,
     #[error("resource {0:?} names artifact {1:?}, which is absent or outside its platform scope")]
     ResourceArtifact(String, String),
+    #[error(
+        "resource {0:?} names a path inside artifact {1:?}, which is a bare {2} executable and holds no paths"
+    )]
+    ResourceArchiveInBareArtifact(String, String, String),
     #[error("resource {0:?} must have exactly one of archive, asset, repo, exec")]
     ResourceSource(String),
     #[error("resource {0:?}: {1} path must be relative with no empty or .. segments")]
@@ -1464,6 +1473,23 @@ impl Statement {
                 return Err(InvalidDocument::ResourceKind);
             }
             check_extensions(&format!("resource {label:?}"), &resource.extensions)?;
+            // Said before the scope check below, which would otherwise
+            // report this as a platform mismatch.
+            if resource.archive.is_some()
+                && let Some(name) = &resource.artifact
+                && let Some(format) = p
+                    .artifacts
+                    .iter()
+                    .find(|a| &a.name == name)
+                    .and_then(|a| a.format.as_deref())
+                && is_bare_format(format)
+            {
+                return Err(InvalidDocument::ResourceArchiveInBareArtifact(
+                    label,
+                    name.clone(),
+                    format.to_string(),
+                ));
+            }
             if let Some(name) = &resource.artifact
                 && !p.artifacts.iter().any(|a| resource_fits(resource, a))
             {
@@ -2854,7 +2880,6 @@ mod tests {
         for (name, format, variant) in [
             ("mise.zip", "zip", None),
             ("mise-fips.tar.xz", "tar.xz", Some("fips")),
-            ("mise", "raw", None),
         ] {
             let other = Artifact {
                 name: name.into(),
@@ -2868,6 +2893,41 @@ mod tests {
                 vec![&s.predicate.resources[0]]
             );
         }
+        // A bare executable holds no paths, so neither archive entry
+        // reaches it, scope or no scope.
+        let bare = Artifact {
+            name: "mise".into(),
+            format: Some("raw".into()),
+            ..target.clone()
+        };
+        assert!(!resource_fits(&exact, &bare));
+        assert!(!resource_fits(&fallback, &bare));
+        assert!(select_resources(&s, &bare).is_empty());
+        // The same completion reaches it from an asset.
+        let asset = Resource {
+            archive: None,
+            asset: Some("mise-completions.tar.gz".into()),
+            url: Some("https://example.com/mise-completions.tar.gz".into()),
+            ..fallback.clone()
+        };
+        assert!(resource_fits(&asset, &bare));
+        // Naming a bare artifact from an archive entry is refused outright,
+        // rather than read as a platform mismatch.
+        let mut wrong = sample();
+        let bare_name = wrong.predicate.artifacts[0].name.clone();
+        wrong.predicate.artifacts[0].format = Some("raw".into());
+        // A bare artifact's executable is the artifact itself.
+        wrong.predicate.artifacts[0].bin = vec![Bin::named(bare_name.clone(), "mise")];
+        wrong.predicate.resources = vec![Resource {
+            artifact: Some(bare_name),
+            archive: Some("share/_mise".into()),
+            shell: Some("zsh".into()),
+            ..Resource::new("completion")
+        }];
+        assert!(matches!(
+            wrong.validate(),
+            Err(InvalidDocument::ResourceArchiveInBareArtifact(_, _, _))
+        ));
         s.predicate.resources[1].artifact = Some("missing.tar.xz".into());
         assert!(matches!(
             s.validate(),


### PR DESCRIPTION
Found while putting packslip into mise's release run ([jdx/mise#12812](https://github.com/jdx/mise/pull/12812)).

An `archive` entry names a path inside the artifact the consumer selected. A bare-format artifact — `raw`, or a single compressed executable — has no paths inside it: it *is* the executable. Nothing said so, so an unscoped

```toml
[[resource]]
kind = "man"
archive = "mise/man/man1/mise.1"
```

applied to `mise-v2026.9.1-linux-x64` exactly as readily as to `mise-v2026.9.1-linux-x64.tar.gz`. A consumer that selected the bare executable was told to go looking for a path inside a 120 MB ELF binary.

mise publishes three tarball formats *and* a bare executable for every platform, so the only way to say "the man page is in the archives" was to name each archive artifact by hand — eighteen generated `[[resource]]` entries to express one fact, and they have to be regenerated per release because the file names carry the version.

### The rule

`resource_fits` now excludes an `archive` source paired with a bare-format artifact. It bears on the source rather than the resource, so the same man page can still reach a bare artifact through an `asset` or `repo` entry — only the archive path is meaningless there.

With this, mise's whole manifest collapses to one entry:

```toml
[[resource]]
kind = "man"
archive = "mise/man/man1/mise.1"
```

Verified against mise's real v2026.9.1 assets: the entry lands in the document, validates, and `resource_fits` returns false for both bare executables.

Naming a bare artifact from an `archive` entry is now its own document error rather than being reported as "absent or outside its platform scope", which was the wrong diagnosis for a vendor who had the artifact name exactly right.

The spec's example for the `artifact` selector used to be this very case — a man page in `tool-linux-x64.tar.xz` naming its artifact so as not to claim the bare `tool-linux-x64` holds one. Since that no longer needs a selector, the example is now a variant with a different layout, which does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core resource matching and validation semantics; consumers and publishers relying on archive entries applying to bare artifacts will see different behavior, though the fix matches intended spec behavior.
> 
> **Overview**
> **Archive-backed resources no longer match bare executables.** `resource_fits` (and thus `select_resources`) now treats an `archive` entry as inapplicable when the selected artifact’s `format` is bare (`raw`, `gz`, `xz`, `zst`, `bz2`), so consumers are not directed to hunt for paths inside a single binary. The same logical resource can still apply to a bare artifact via `asset` or `repo`.
> 
> **Validation and docs align with that rule.** Manifest validation rejects an `archive` resource that explicitly names a bare artifact (`ResourceArchiveInBareArtifact`) instead of misreporting a platform scope problem. The spec (and mirrored docs) state the rule, narrow the `archive` source description, and swap the `artifact` selector example to a variant/layout case rather than bare-vs-tarball workarounds.
> 
> Tests cover bare selection (empty resources), asset fallback, and the new validation error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c72d9ecd6f5a1dcac7823d7c45b166878f7791a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->