### PR TITLE
fix(create): every artifact says what kind of file it is

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,14 @@ inputs:
       whitespace separated (tool-fips-linux-x64.tar.gz=fips).
     required: false
     default: ""
+  formats:
+    description: >
+      The format of an artifact whose name does not say, as FILENAME=FORMAT,
+      whitespace separated (tool-linux-x64.bin=raw). Every artifact needs
+      one; the name gives it for the usual archive, installer, and bare
+      executable spellings, and this is for the rest.
+    required: false
+    default: ""
   resources:
     description: >
       What ships besides the executables, one per line, each a `packslip
@@ -246,6 +254,7 @@ runs:
         IN_BIN: ${{ inputs.bin }}
         IN_MANIFEST: ${{ inputs.manifest }}
         IN_VARIANTS: ${{ inputs.variants }}
+        IN_FORMATS: ${{ inputs.formats }}
         IN_RESOURCES: ${{ inputs.resources }}
         IN_REQUIRE: ${{ inputs.require }}
         IN_NOTES_URL: ${{ inputs.notes-url }}
@@ -301,6 +310,10 @@ runs:
             args+=(--provenance "${f##*/}=${API}/repos/${REPO}/attestations/sha256:${digest}")
           done
         fi
+        # A file name the format inference cannot read is given one.
+        for spec in $IN_FORMATS; do
+          args+=(--format "$spec")
+        done
         # Artifacts sharing a platform carry the variant given for them.
         declare -A variants=()
         for spec in $IN_VARIANTS; do

--- a/content/cli/create.md
+++ b/content/cli/create.md
@@ -26,6 +26,7 @@ Examples and configuration: https://packslip.dev/docs/describing-releases/
   **Default:** `.`
 - **`--url-base <URL_BASE>`** — Download URL prefix for the artifacts
 - **`--url <URL>`** — Download URL for one artifact or resource asset, as FILENAME=URL (repeatable)
+- **`--format <FORMAT>`** — Format of one artifact whose name does not say, as FILENAME=FORMAT: an archive (tar.xz, tar.gz, tar.zst, tar.bz2, tgz, tar, zip, 7z), a single compressed executable (gz, xz, zst, bz2), an installer (deb, rpm, dmg, pkg, msi, msix, exe, appimage), raw for a bare executable, or a type of your own (repeatable)
 - **`--source-repo <SOURCE_REPO>`** — Source repository URL
 - **`--commit <COMMIT>`** — Source commit
 - **`--tag <TAG>`** — Source tag

--- a/content/docs/publishing.md
+++ b/content/docs/publishing.md
@@ -156,6 +156,7 @@ is not checked at all, so the job vouches for where it came from.
 | `tag` | Existing release tag; defaults to the triggering tag. |
 | `manifest` | Path to a TOML manifest. Its artifact entries join the matched files. |
 | `variants` | Whitespace-separated `FILENAME=VARIANT` entries. |
+| `formats` | Whitespace-separated `FILENAME=FORMAT` entries, for an artifact whose name does not say what it is. |
 | `resources` | One resource declaration per line. Add `@os[/arch[/libc]]` after the kind to scope one to a platform. |
 | `require` | One `bin:NAME[@MIN]` requirement per line. |
 | `extensions` | One `NAME=JSON` extension per line. |

--- a/content/spec.md
+++ b/content/spec.md
@@ -300,6 +300,16 @@ a package manager that installs into its own directory does not unpack
 them. A `.exe` that is the program itself is `raw`; `exe` means a
 Windows installer.
 
+Every artifact carries a `format`. Selecting an artifact keeps only the
+formats the consumer handles, and no consumer handles an absent one, so
+an artifact without it could never be selected: it would claim a place
+in the release while being unusable. A vendor whose file name says
+nothing states the format outright, and a file that is not an artifact
+at all -- a shared library, a header, a checksum sidecar -- is left out
+of `artifacts` rather than published as one. The value is not a closed
+set; a vendor may name a type this specification does not, and consumers
+skip what they cannot open.
+
 ### Field reference
 
 Required fields inside an optional object are required when that object is
@@ -329,7 +339,7 @@ include `repo`. Resource entries must choose exactly one source field.
 | `artifacts[].variant` | string | optional | Distinguishes builds sharing os, arch, and libc: `fips`, `baseline`, `debug`, `installer`, `source`. |
 | `artifacts[].size` | integer | required | File size in bytes. Verified alongside the digest. |
 | `artifacts[].url` | string | optional | Download URL. |
-| `artifacts[].format` | string | optional | Archive, compression, or installer type, or `raw` for a bare executable. |
+| `artifacts[].format` | string | required | Archive, compression, or installer type, or `raw` for a bare executable. |
 | `artifacts[].bin[]` | array of string or object | optional | Executables inside the artifact: a path from the archive root, or `{ path, name }` when the PATH name differs. A name is the command as typed, without `.exe`. |
 | `artifacts[].requires` | object | optional | What the host must provide. See Host requirements. |
 | `requires.os_min` | string | optional | Minimum OS version in the OS's own terms. |

--- a/docs/spec/packslip.md
+++ b/docs/spec/packslip.md
@@ -296,6 +296,16 @@ a package manager that installs into its own directory does not unpack
 them. A `.exe` that is the program itself is `raw`; `exe` means a
 Windows installer.
 
+Every artifact carries a `format`. Selecting an artifact keeps only the
+formats the consumer handles, and no consumer handles an absent one, so
+an artifact without it could never be selected: it would claim a place
+in the release while being unusable. A vendor whose file name says
+nothing states the format outright, and a file that is not an artifact
+at all -- a shared library, a header, a checksum sidecar -- is left out
+of `artifacts` rather than published as one. The value is not a closed
+set; a vendor may name a type this specification does not, and consumers
+skip what they cannot open.
+
 ### Field reference
 
 Required fields inside an optional object are required when that object is
@@ -325,7 +335,7 @@ include `repo`. Resource entries must choose exactly one source field.
 | `artifacts[].variant` | string | optional | Distinguishes builds sharing os, arch, and libc: `fips`, `baseline`, `debug`, `installer`, `source`. |
 | `artifacts[].size` | integer | required | File size in bytes. Verified alongside the digest. |
 | `artifacts[].url` | string | optional | Download URL. |
-| `artifacts[].format` | string | optional | Archive, compression, or installer type, or `raw` for a bare executable. |
+| `artifacts[].format` | string | required | Archive, compression, or installer type, or `raw` for a bare executable. |
 | `artifacts[].bin[]` | array of string or object | optional | Executables inside the artifact: a path from the archive root, or `{ path, name }` when the PATH name differs. A name is the command as typed, without `.exe`. |
 | `artifacts[].requires` | object | optional | What the host must provide. See Host requirements. |
 | `requires.os_min` | string | optional | Minimum OS version in the OS's own terms. |

--- a/packslip.usage.kdl
+++ b/packslip.usage.kdl
@@ -47,6 +47,9 @@ Examples and configuration: https://packslip.dev/docs/describing-releases/
     flag --url help="Download URL for one artifact or resource asset, as FILENAME=URL (repeatable)" var=#true {
         arg <URL>
     }
+    flag --format help="Format of one artifact whose name does not say, as FILENAME=FORMAT: an archive (tar.xz, tar.gz, tar.zst, tar.bz2, tgz, tar, zip, 7z), a single compressed executable (gz, xz, zst, bz2), an installer (deb, rpm, dmg, pkg, msi, msix, exe, appimage), raw for a bare executable, or a type of your own (repeatable)" var=#true {
+        arg <FORMAT>
+    }
     flag --source-repo help="Source repository URL" {
         arg <SOURCE_REPO>
     }

--- a/src/create.rs
+++ b/src/create.rs
@@ -162,6 +162,10 @@ pub enum Error {
         b: String,
         platform: String,
     },
+    #[error(
+        "artifact {name:?}: nothing in the name says what kind of file it is; give it a format, or leave it out of the artifacts if it is not one"
+    )]
+    UnknownFormat { name: String },
 }
 
 /// The `(os, arch, libc, format)` a file name implies.
@@ -365,6 +369,14 @@ pub fn create(request: &Request<'_>) -> Result<Created, Error> {
                 (!has_extension(&name) && (os.is_some() || input.portable))
                     .then(|| "raw".to_string())
             });
+        // An artifact with no format is dead weight: rule 3 of Selecting
+        // an artifact keeps a consumer from ever choosing one, so it
+        // would ship a digest and a platform that nothing can act on.
+        // A library or a header swept up by a glob lands here.
+        let Some(format) = format else {
+            return Err(Error::UnknownFormat { name });
+        };
+        let format = Some(format);
         let bare = format
             .as_deref()
             .filter(|f| crate::model::is_bare_format(f))
@@ -1127,6 +1139,7 @@ mod tests {
                 },
                 ArtifactInput {
                     portable: true,
+                    format: Some("jar".into()),
                     ..ArtifactInput::new(&jar)
                 },
             ],
@@ -1141,7 +1154,29 @@ mod tests {
             (&arts[1].os, &arts[1].arch, &arts[1].libc),
             (&None, &None, &None)
         );
-        assert_eq!(arts[1].format, None);
+        assert_eq!(arts[1].format.as_deref(), Some("jar"));
+
+        // `.jar` is no format the name inference knows, and running it is
+        // not something a consumer could guess, so without that override
+        // the file is refused rather than published unusable. A header or
+        // a shared library swept up by an artifacts glob lands here too.
+        let header = dir.path().join("tool.h");
+        std::fs::write(&header, b"#pragma once").unwrap();
+        for path in [&jar, &header] {
+            let err = create(&request(
+                vec![ArtifactInput {
+                    portable: true,
+                    ..ArtifactInput::new(path)
+                }],
+                None,
+                None,
+            ))
+            .unwrap_err();
+            assert!(
+                matches!(err, Error::UnknownFormat { .. }),
+                "{path:?}: {err}"
+            );
+        }
 
         // A portable file with no extension is still a bare executable, and
         // a bare Windows file without .exe keeps its exact name as the path.

--- a/src/main.rs
+++ b/src/main.rs
@@ -316,6 +316,13 @@ struct Create {
     /// Download URL for one artifact or resource asset, as FILENAME=URL (repeatable)
     #[usage(long)]
     url: Vec<String>,
+    /// Format of one artifact whose name does not say, as FILENAME=FORMAT:
+    /// an archive (tar.xz, tar.gz, tar.zst, tar.bz2, tgz, tar, zip, 7z), a
+    /// single compressed executable (gz, xz, zst, bz2), an installer (deb,
+    /// rpm, dmg, pkg, msi, msix, exe, appimage), raw for a bare
+    /// executable, or a type of your own (repeatable)
+    #[usage(long)]
+    format: Vec<String>,
     /// Source repository URL
     #[usage(long)]
     source_repo: Option<String>,
@@ -616,6 +623,16 @@ impl RunWith<BinInfo> for Create {
             };
             urls.insert(name.to_string(), url.to_string());
         }
+        let mut formats = std::collections::BTreeMap::new();
+        for spec in &self.format {
+            let Some((name, format)) = spec.split_once('=') else {
+                bail!("--format wants FILENAME=FORMAT, got {spec:?}");
+            };
+            if format.is_empty() {
+                bail!("--format {spec:?} has an empty format");
+            }
+            formats.insert(name.to_string(), format.to_string());
+        }
         // The manifest's extensions first; a flag naming the same key wins.
         let mut extensions = manifest.extensions.clone();
         let mut from_flags = Extensions::new();
@@ -689,7 +706,7 @@ impl RunWith<BinInfo> for Create {
                 portable: entry.portable,
                 variant: entry.variant.clone(),
                 url: entry.url.clone().or_else(|| urls.get(name).cloned()),
-                format: entry.format.clone(),
+                format: entry.format.clone().or_else(|| formats.get(name).cloned()),
                 bin: entry.bins(&default_bins).to_vec(),
                 requires: entry.requirements(manifest.requires.as_ref()),
                 provenance: provenance_of(name, &entry.provenance),
@@ -713,7 +730,7 @@ impl RunWith<BinInfo> for Create {
                 portable: arg.portable,
                 variant: arg.variant.clone(),
                 url: urls.get(name).cloned(),
-                format: None,
+                format: formats.get(name).cloned(),
                 bin: default_bins.clone(),
                 requires: manifest.requires.clone(),
                 provenance: provenance_of(name, &[]),
@@ -764,6 +781,11 @@ impl RunWith<BinInfo> for Create {
                 && !asset_paths.iter().any(|p| file_name_of(p) == name)
             {
                 bail!("--url names {name:?}, which is not among the artifacts or assets");
+            }
+        }
+        for name in formats.keys() {
+            if !artifacts.iter().any(|a| file_name_of(a.path) == name) {
+                bail!("--format names {name:?}, which is not among the artifacts");
             }
         }
         let source = source_repo.map(|repo| Source {

--- a/src/model.rs
+++ b/src/model.rs
@@ -523,9 +523,17 @@ pub struct Artifact {
     /// `zst`, `bz2`), an installer (`deb`, `rpm`, `dmg`, `pkg`, `msi`,
     /// `msix`, `exe`, `appimage`), or `raw` for a bare executable. Two
     /// artifacts that differ only in format carry the same build, and a
-    /// consumer takes whichever it prefers.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "schema", schemars(regex(pattern = TOKEN_PATTERN)))]
+    /// consumer takes whichever it prefers. Required: an artifact whose
+    /// format is unknown is one no consumer can select.
+    ///
+    /// `Option` so that a document leaving it out still parses and is
+    /// then refused by `validate`, which can name the artifact. The field
+    /// is not optional: no `serde(default)`, so the schema demands it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        feature = "schema",
+        schemars(required, regex(pattern = TOKEN_PATTERN))
+    )]
     pub format: Option<String>,
     /// Executables inside the artifact, as paths relative to the archive
     /// root, or the artifact's own name (minus any compression suffix)
@@ -1189,6 +1197,8 @@ pub enum InvalidDocument {
     AmbiguousArtifacts(String, String),
     #[error("at least one artifact is required")]
     NoArtifacts,
+    #[error("artifact {0:?} has no format, so no consumer can select it")]
+    ArtifactFormat(String),
     #[error("a resource has an empty kind")]
     ResourceKind,
     #[error("resource {0:?} names artifact {1:?}, which is absent or outside its platform scope")]
@@ -1349,6 +1359,11 @@ impl Statement {
             )?;
             if !self.subject.iter().any(|s| s.name == artifact.name) {
                 return Err(InvalidDocument::OrphanArtifact(artifact.name.clone()));
+            }
+            // Rule 3 of Selecting an artifact skips a format the consumer
+            // does not handle, and no consumer handles an absent one.
+            if artifact.format.is_none() {
+                return Err(InvalidDocument::ArtifactFormat(artifact.name.clone()));
             }
             for (field, value) in [
                 ("os", &artifact.os),
@@ -3310,12 +3325,16 @@ mod tests {
             s.validate(),
             Err(InvalidDocument::AmbiguousArtifacts(_, _))
         ));
-        // Without a format neither is selectable, so nothing is ambiguous.
+        // An artifact with no format is not ambiguous with anything, for
+        // the reason it is refused outright: no consumer can select it.
         for artifact in &mut s.predicate.artifacts {
             artifact.format = None;
             artifact.bin.clear();
         }
-        s.validate().unwrap();
+        assert!(matches!(
+            s.validate(),
+            Err(InvalidDocument::ArtifactFormat(_))
+        ));
     }
 
     #[test]
@@ -3331,5 +3350,35 @@ mod tests {
             text.contains("attested_by") && text.contains("variant"),
             "{text}"
         );
+        // `format` is Option in Rust only so that an explicit null is
+        // reported by validate; the schema must still demand it.
+        assert!(
+            text.contains(r#""required":["name","size","format"]"#),
+            "{text}"
+        );
+    }
+
+    #[test]
+    fn an_artifact_without_a_format_is_refused() {
+        // A null reaches validate and is named there.
+        let mut s = sample();
+        s.predicate.artifacts[0].format = None;
+        s.predicate.artifacts[0].bin.clear();
+        assert!(matches!(
+            s.validate(),
+            Err(InvalidDocument::ArtifactFormat(_))
+        ));
+        // An omitted key parses, so the refusal names the artifact rather
+        // than arriving as a serde message about a field.
+        let mut json = serde_json::to_value(sample()).unwrap();
+        let artifact = &mut json["predicate"]["artifacts"][0];
+        artifact.as_object_mut().unwrap().remove("format");
+        artifact["bin"] = serde_json::json!([]);
+        let parsed: Statement = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed.predicate.artifacts[0].format, None);
+        assert!(matches!(
+            parsed.validate(),
+            Err(InvalidDocument::ArtifactFormat(name)) if name == parsed.predicate.artifacts[0].name
+        ));
     }
 }

--- a/static/schema/release-v1.json
+++ b/static/schema/release-v1.json
@@ -23,12 +23,9 @@
           "type": "object"
         },
         "format": {
-          "description": "The archive type (`tar.xz`, `tar.gz`, `tar.zst`, `tar.bz2`, `tgz`,\n`tar`, `zip`, `7z`), a single compressed executable (`gz`, `xz`,\n`zst`, `bz2`), an installer (`deb`, `rpm`, `dmg`, `pkg`, `msi`,\n`msix`, `exe`, `appimage`), or `raw` for a bare executable. Two\nartifacts that differ only in format carry the same build, and a\nconsumer takes whichever it prefers.",
+          "description": "The archive type (`tar.xz`, `tar.gz`, `tar.zst`, `tar.bz2`, `tgz`,\n`tar`, `zip`, `7z`), a single compressed executable (`gz`, `xz`,\n`zst`, `bz2`), an installer (`deb`, `rpm`, `dmg`, `pkg`, `msi`,\n`msix`, `exe`, `appimage`), or `raw` for a bare executable. Two\nartifacts that differ only in format carry the same build, and a\nconsumer takes whichever it prefers. Required: an artifact whose\nformat is unknown is one no consumer can select.\n\n`Option` so that a document leaving it out still parses and is\nthen refused by `validate`, which can name the artifact. The field\nis not optional: no `serde(default)`, so the schema demands it.",
           "pattern": "^[a-z0-9][a-z0-9_.-]*$",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "libc": {
           "description": "`gnu` or `musl`, for a Linux build. Absent when the artifact does\nnot depend on one.",
@@ -89,7 +86,8 @@
       },
       "required": [
         "name",
-        "size"
+        "size",
+        "format"
       ],
       "type": "object"
     },

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -79,6 +79,10 @@ fn keygen_create_verify_show_and_list() {
             "2026-09-01T00:00:00Z",
             "--bin",
             "tool",
+            // Nothing in `weird.bin` says what kind of file it is, so the
+            // vendor says.
+            "--format",
+            "weird.bin=raw",
             "tool-v1.2.3-linux-x64.tar.xz",
             "tool-v1.2.3-darwin-arm64.tar.xz",
             "weird.bin:freebsd/riscv64",


### PR DESCRIPTION
Found while putting packslip into the release runs of the jdx.dev CLIs.

Rule 3 of *Selecting an artifact* keeps only the formats the consumer handles, and no consumer handles an absent one — `select_artifact` skips such an artifact outright. Nothing refused it on the way in, so a release could publish an artifact that claimed a platform and a digest while being unselectable by construction.

That is not hypothetical. Running `packslip create` over aube's real v2.2.9 release assets:

```
aube-v2.2.9-aarch64-apple-darwin.tar.gz | darwin  aarch64  -   tar.gz
libaube-aarch64-apple-darwin.dylib      | darwin  aarch64  -   (none)
libaube-x86_64-pc-windows-msvc.dll      | windows x86_64   -   (none)
aube.h                                  |   -       -      -   (none)
```

A shared library was accepted as a darwin/aarch64 artifact sitting beside the CLI archive for the same platform, and a C header as an artifact with no os, no arch, and no format at all. Both are files an `artifacts` glob swept up, neither is anything anyone installs, and the tool said nothing. The aube PR works around it by narrowing the glob — which is right, but it should not have taken reading the output to find out.

### The change

`format` is required, said in all four places that have to agree:

- the specification's field table, with a paragraph in *Artifact platforms and formats* giving the reason
- the JSON schema, which now lists it in `required`
- `validate`, which refuses a document without one **by artifact name** rather than letting it through
- `create`, which refuses to write one and names the two ways out

A file that is not an artifact gets left out of `artifacts`. One whose name the inference cannot read gets told what it is.

### Saying so without a manifest

That last part needed a way to say it, or the rule would push people to a TOML manifest for a one-word fact. `--format FILENAME=FORMAT` joins the existing `--url` and `--provenance` flags, and the action grows a matching `formats` input beside `variants`:

```yaml
- uses: jdx/packslip@v0
  with:
    artifacts: dist/*
    formats: tool-linux-x64.bin=raw
```

The value stays open — a vendor may name a type this specification does not, and consumers skip what they cannot open.

### Blast radius

Two existing tests encoded the old behaviour and both were arguments for the change:

- a portable `tool-linux.jar` published with no format; it now passes `format = "jar"`, which is strictly more useful to a consumer, and the refusal is asserted alongside.
- `// Without a format neither is selectable, so nothing is ambiguous` — the code already knew.

Re-verified against the real assets of every jdx.dev CLI: mise, fnox, hk, pitchfork, usage, communique, mbx, tak, and aube's CLI archives all still create cleanly, and the aube glob that includes the FFI files now fails with the file named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for release workflows and any existing bundles missing `format`; broad artifact globs may now fail at create time until formats are set or files are excluded.
> 
> **Overview**
> Every artifact in a signed release must now declare a **`format`**, because consumers skip entries with no format during selection—so publishing one without it produced unusable manifest noise (e.g. FFI `.dylib` files or headers picked up by globs).
> 
> **Enforcement** is aligned across the spec, JSON schema (`format` required), **`validate`** (names the artifact), and **`packslip create`** (new **`UnknownFormat`** when inference and overrides leave format empty). **`--format FILENAME=FORMAT`** supplies per-file formats without a manifest; the GitHub Action adds a matching **`formats`** input wired like **`variants`**.
> 
> Custom types (e.g. **`jar`**) stay valid when the vendor sets them explicitly; files that are not installable artifacts should be omitted from **`artifacts`** rather than given a format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e81cf914d7e7952726f1818463534ea85211d301. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->