### PR TITLE
ci: enforce conventional commits

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,27 @@
+name: conventional-commits
+
+on: # zizmor: ignore[dangerous-triggers] reads only the PR title and executes no untrusted code
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check pull request title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(chore|ci|docs|feat|fix|perf|refactor|release|revert|security|spec|style|test)(\([[:alnum:]][[:alnum:]./_-]*\))?!?: [[:lower:]](.*[[:graph:]])?$'
+          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+            echo "::error title=Invalid pull request title::The title does not match the required format."
+            printf 'Received title: %q\n' "$PR_TITLE"
+            echo "Use: <type>[optional scope][optional !]: <description starting lowercase>"
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Contributor Instructions
+
+## Conventional Commits
+
+Pull request titles must use the following format; intermediate commit subjects
+should use it too:
+
+```text
+<type>[optional scope][optional !]: <description>
+```
+
+Start the description with a lowercase character and keep it concise and imperative. Use `!` before the colon for a
+breaking change and explain it in the commit body with a `BREAKING CHANGE:`
+footer.
+
+Allowed types are `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`,
+`release`, `revert`, `security`, `spec`, `style`, and `test`.
+
+Examples:
+
+- `feat(create): add archive resource metadata`
+- `fix!: reject an unsupported manifest version`
+- `docs: clarify keyless verification`
+
+CI validates the pull request title and re-runs when it is edited. Intermediate
+commit subjects are not checked because pull requests are squash-merged. CI
+mechanically checks the allowed type, syntax, and lowercase-leading description;
+imperative mood and breaking-change details remain review rules.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

- document or connect the repository’s Conventional Commits policy for pull request titles
- validate the title on creation and every edit with the repository’s allowed types
- use a permissionless `pull_request_target` workflow with no checkout, so pull request code cannot bypass the check
- intentionally ignore intermediate commit subjects because pull requests are squash-merged using their titles

## Testing

- `actionlint .github/workflows/conventional-commits.yml`
- exercised valid, breaking-change, invalid-type, uppercase-description, and trailing-space title cases locally

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a read-only CI gate on PR metadata; no application code or privileged workflow steps beyond title regex validation.
> 
> **Overview**
> Adds **automated PR title validation** for Conventional Commits and documents the policy for contributors.
> 
> A new GitHub Actions workflow runs on `pull_request_target` (open/edit/reopen/sync) with **empty permissions** and **no checkout**, matching titles against allowed types (`feat`, `fix`, `ci`, etc.), optional scope, optional `!`, and a **lowercase-leading** description. Failed checks emit a workflow error with format guidance. Concurrency is scoped per PR so reruns cancel stale jobs.
> 
> **`AGENTS.md`** defines the title format, allowed types, examples, and notes that only squash-merge titles are checked—not individual commits. **`CLAUDE.md`** now points agents at that file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d19fb58135345b93ce6592ab227ed2d16c0db1fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->