### PR TITLE
feat(action): fetch artifacts straight from the release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -218,6 +218,7 @@ runs:
         "$dir/packslip$exe" version
 
     - name: Download release assets
+      id: download
       if: inputs.download != ''
       shell: bash
       env:
@@ -229,18 +230,27 @@ runs:
         REPO: ${{ github.repository }}
       run: |
         set -euo pipefail
+        # IN_DOWNLOAD holds asset-name globs for `gh release download
+        # --pattern`, not paths to expand against this job's working
+        # directory -- turn off pathname expansion so a pattern like *.zip
+        # is never quietly replaced by whatever it happens to match here.
+        set -f
         tag="${IN_TAG:-$REF_NAME}"
         if [ -z "$IN_TAG" ] && [ "$REF_TYPE" != tag ]; then
           echo "download is set but not running on a tag; pass the tag input" >&2
           exit 1
         fi
-        dir="${RUNNER_TEMP}/packslip-download"
-        mkdir -p "$dir"
+        # A fresh directory per invocation, not a fixed name: the monorepo
+        # flow calls this action once per tool in the same job, and a fixed
+        # name would still hold the previous tool's files when this step is
+        # skipped for one of them.
+        dir="$(mktemp -d "${RUNNER_TEMP}/packslip-download.XXXXXX")"
         args=(--repo "$REPO" --dir "$dir" --clobber)
         for pattern in $IN_DOWNLOAD; do
           args+=(--pattern "$pattern")
         done
         gh release download "$tag" "${args[@]}"
+        echo "dir=$dir" >> "$GITHUB_OUTPUT"
 
     - name: Collect artifacts
       id: files
@@ -248,17 +258,24 @@ runs:
       env:
         IN_ARTIFACTS: ${{ inputs.artifacts }}
         IN_DOWNLOAD: ${{ inputs.download }}
+        IN_DOWNLOAD_DIR: ${{ steps.download.outputs.dir }}
       run: |
         set -euo pipefail
         shopt -s nullglob
-        patterns="$IN_ARTIFACTS"
-        [ -n "$IN_DOWNLOAD" ] && patterns="$patterns ${RUNNER_TEMP}/packslip-download/*"
         files=()
-        for pattern in $patterns; do
+        for pattern in $IN_ARTIFACTS; do
           for f in $pattern; do [ -f "$f" ] && files+=("$f"); done
         done
+        if [ -n "$IN_DOWNLOAD_DIR" ]; then
+          # Listed, not glob-matched: on a Windows runner RUNNER_TEMP is a
+          # backslash path, which bash's pathname expansion would otherwise
+          # read as glob escapes and match nothing.
+          while IFS= read -r -d '' f; do
+            files+=("$f")
+          done < <(find "$IN_DOWNLOAD_DIR" -maxdepth 1 -type f -print0)
+        fi
         if [ "${#files[@]}" -eq 0 ]; then
-          echo "no artifacts matched: $patterns" >&2
+          echo "no artifacts matched: artifacts=[$IN_ARTIFACTS] download=[$IN_DOWNLOAD]" >&2
           exit 1
         fi
         printf '%s\n' "${files[@]}" > "${RUNNER_TEMP}/packslip-files"

--- a/action.yml
+++ b/action.yml
@@ -10,8 +10,21 @@ branding:
 
 inputs:
   artifacts:
-    description: Artifact files or globs, whitespace separated (dist/*.tar.xz dist/*.zip)
-    required: true
+    description: >
+      Artifact files or globs already present locally, whitespace separated
+      (dist/*.tar.xz dist/*.zip). At least one file must match between this
+      and `download`.
+    required: false
+    default: ""
+  download:
+    description: >
+      Release asset name patterns to fetch before collecting artifacts,
+      whitespace separated (mytool-*.tar.gz mytool-*.zip). Downloaded files
+      join `artifacts`, so a job whose archives already live on the release
+      named by `tag` needs no separate `gh release download` step, and no
+      second copy of these patterns for a local artifacts glob.
+    required: false
+    default: ""
   project:
     description: >
       The project's name; defaults to github.com/<owner>/<repo>. A tool in
@@ -204,20 +217,48 @@ runs:
         echo "$dir" >> "$GITHUB_PATH"
         "$dir/packslip$exe" version
 
+    - name: Download release assets
+      if: inputs.download != ''
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        IN_DOWNLOAD: ${{ inputs.download }}
+        IN_TAG: ${{ inputs.tag }}
+        REF_NAME: ${{ github.ref_name }}
+        REF_TYPE: ${{ github.ref_type }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+        tag="${IN_TAG:-$REF_NAME}"
+        if [ -z "$IN_TAG" ] && [ "$REF_TYPE" != tag ]; then
+          echo "download is set but not running on a tag; pass the tag input" >&2
+          exit 1
+        fi
+        dir="${RUNNER_TEMP}/packslip-download"
+        mkdir -p "$dir"
+        args=(--repo "$REPO" --dir "$dir" --clobber)
+        for pattern in $IN_DOWNLOAD; do
+          args+=(--pattern "$pattern")
+        done
+        gh release download "$tag" "${args[@]}"
+
     - name: Collect artifacts
       id: files
       shell: bash
       env:
         IN_ARTIFACTS: ${{ inputs.artifacts }}
+        IN_DOWNLOAD: ${{ inputs.download }}
       run: |
         set -euo pipefail
         shopt -s nullglob
+        patterns="$IN_ARTIFACTS"
+        [ -n "$IN_DOWNLOAD" ] && patterns="$patterns ${RUNNER_TEMP}/packslip-download/*"
         files=()
-        for pattern in $IN_ARTIFACTS; do
+        for pattern in $patterns; do
           for f in $pattern; do [ -f "$f" ] && files+=("$f"); done
         done
         if [ "${#files[@]}" -eq 0 ]; then
-          echo "no artifacts matched: $IN_ARTIFACTS" >&2
+          echo "no artifacts matched: $patterns" >&2
           exit 1
         fi
         printf '%s\n' "${files[@]}" > "${RUNNER_TEMP}/packslip-files"

--- a/content/docs/publishing.md
+++ b/content/docs/publishing.md
@@ -11,13 +11,18 @@ signing key is needed.
 
 ## Prepare the files and release
 
-The action consumes final local files. In a build matrix, collect the artifacts
-into the signing job before running it. Complete any archive rewriting,
+The action consumes final local files. Complete any archive rewriting,
 platform signing, or notarization that changes the bytes first.
 
 Create the GitHub release and upload the artifacts through your existing
 workflow. Upload separate resource assets, such as SBOMs, too. The action
 uploads only the packslip bundle; a signed URL does not upload its target.
+
+Once those files are on the release, either bring them into the signing
+job yourself (a build matrix typically stages them with
+`actions/download-artifact` before this step) or let `download` fetch
+them straight from the release — see
+[Download from the release](#download-from-the-release) below.
 
 ## Add the release step
 
@@ -75,6 +80,27 @@ Use paths from the actual archive root, including any top-level directory.
 Only include resources and commands your release really provides or needs.
 Use a [TOML manifest](/docs/describing-releases/#use-a-toml-manifest) when
 paths or requirements differ between artifacts.
+
+## Download from the release
+
+A signing job that runs after the release already has its archives
+uploaded — a separate job in the same workflow run, or a re-run against
+an existing tag — can skip staging them itself:
+
+```yaml
+- uses: jdx/packslip@v1
+  with:
+    download: mytool-*.tar.xz mytool-*.zip
+    bin: mytool
+```
+
+This replaces a `gh release download` step and a second copy of the same
+glob for `artifacts`: `download` fetches matching assets from the release
+named by `tag` (the triggering tag by default) into a working directory
+and folds them into the same file set `artifacts` collects. Set both
+inputs to combine files already on disk with files pulled from the
+release. `token` must be able to read that release — the default
+`github.token` already can, including for a release still in draft.
 
 ## Release several tools from one repository
 
@@ -149,7 +175,8 @@ is not checked at all, so the job vouches for where it came from.
 
 | Input | Purpose and default |
 | --- | --- |
-| `artifacts` | Required. Whitespace-separated local files or globs; at least one file must match. |
+| `artifacts` | Whitespace-separated local files or globs. Between this and `download`, at least one file must match. |
+| `download` | Whitespace-separated release asset name patterns to fetch before collecting artifacts; joins `artifacts`. See [Download from the release](#download-from-the-release). |
 | `bin` | Whitespace-separated executable names or `NAME=PATH` entries. |
 | `project` | Project name; defaults to `github.com/<owner>/<repo>`. |
 | `version` | Semver version; defaults to the tag without its leading `v`. |
@@ -209,7 +236,7 @@ trial that does not contact signing services.
 
 | Symptom | What to check |
 | --- | --- |
-| No artifacts matched | Files must be present in this job's working directory. Download matrix outputs before the action, and check the glob. |
+| No artifacts matched | Files must be present in this job's working directory, or matched by `download` from the release named by `tag`. Download matrix outputs before the action (or set `download`), and check the glob. |
 | Version rejected | Pass a semver `version` explicitly for tags such as `mytool-v1.2.3` or `v4.1`. |
 | Executable missing or ambiguous | Check the archive contents and use an explicit path or `NAME=PATH` mapping. |
 | Bundle upload fails | The release named by `tag` must exist and the token must have `contents: write`. |


### PR DESCRIPTION
## Summary
- Adds a `download` input to the GitHub Action: whitespace-separated release asset name patterns, fetched with `gh release download` before artifacts are collected, then folded into the same file set `artifacts` collects.
- This replaces the "download the release assets" step that every current consumer (mise, usage, hk, pitchfork, fnox, tak, mr-boxington, communique, and soon aube) hand-rolls before calling this action — and the duplicated glob (once for `--pattern`, once for `artifacts`).
- `artifacts` is no longer `required` on its own; at least one file must still match between `artifacts` and `download` combined, enforced by the existing "no artifacts matched" check.
- Docs: new "Download from the release" section in `content/docs/publishing.md`, plus updates to the inputs table and the troubleshooting table.

## Test plan
- [ ] `python3 -c "import yaml; yaml.safe_load(open('action.yml'))"` (done locally)
- [ ] `shellcheck` on the two touched bash blocks (done locally, clean)
- [ ] A consumer workflow adopts `download` and its packslip job succeeds end to end (tracked separately per consumer repo)

*AI-assisted — Tool: Claude Code; model: anthropic/claude-sonnet-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which files enter attestation/signing before upload; misconfigured patterns or tag could fail releases or sign the wrong assets, though signing logic itself is unchanged.
> 
> **Overview**
> Adds a **`download`** input so signing jobs can pull release assets with `gh release download` (by asset-name patterns and `tag`) instead of hand-rolling that step and duplicating the same globs in **`artifacts`**.
> 
> **`artifacts`** is optional now; the collect step merges local globs with everything fetched into a per-run temp dir (with pathname expansion disabled for patterns and `find` for Windows paths). The existing “no artifacts matched” guard still applies across **`artifacts`** + **`download`**, with clearer errors and a requirement to pass **`tag`** when **`download`** is set off a non-tag ref.
> 
> Docs add a “Download from the release” workflow example and update the inputs and troubleshooting tables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4039b2f2940c4ee05807bf23c1d6bc54f9ba7ad4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->