### PR TITLE
fix(action): pass --repo when uploading the packslip

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -406,11 +406,14 @@ runs:
         BUNDLE: ${{ steps.create.outputs.bundle }}
       run: packslip verify "$BUNDLE"
 
+    # `--repo` is not optional here: without it `gh` asks git which repository
+    # it is in, and a job that only downloads artifacts has no checkout to ask.
     - name: Upload to the release
       if: inputs.upload == 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
+        REPO: ${{ github.repository }}
         TAG: ${{ steps.create.outputs.tag }}
         BUNDLE: ${{ steps.create.outputs.bundle }}
-      run: gh release upload "$TAG" "$BUNDLE" --clobber
+      run: gh release upload "$TAG" "$BUNDLE" --repo "$REPO" --clobber


### PR DESCRIPTION
The upload step ran `gh release upload "$TAG" "$BUNDLE" --clobber` with no `--repo`, so `gh` fell back to asking git which repository it was in. Callers that assemble the release in a job that only downloads artifacts have no checkout, and the step failed with

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

after the packslip had already been created and verified. jdx/mr-boxington ([run](https://github.com/jdx/mr-boxington/actions/runs/33975086489/job/101332822913)) and jdx/tak ([run](https://github.com/jdx/tak/actions/runs/33964946456)) both hit this today; jdx/communique only avoids it by setting `GH_REPO` on the step.

Every other `gh` call in the action already passes `--repo`. This makes the upload match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI action change that fixes release upload in no-checkout jobs; no auth or application logic changes.
> 
> **Overview**
> The **Upload to the release** step now passes **`--repo`** to `gh release upload`, using **`github.repository`** via a new `REPO` env var, so upload no longer depends on a local git checkout.
> 
> Without that flag, `gh` infers the repo from git; jobs that only download artifacts and never checkout fail after packslip create/verify with *not a git repository*. A short comment in `action.yml` documents why `--repo` is required here, matching the existing **`gh release download`** step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1da5a4fd0d3713a9d0853b5ae244b219f00bf05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Release uploads now correctly target the intended repository, including workflows that do not check out the source code.
  - Improved reliability for publishing artifacts to GitHub Releases when jobs rely solely on downloaded artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->