### PR TITLE
fix(site): drop the "Experimental" banner now that v1 is stable

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -18,10 +18,9 @@
 <body>
 {{ partial "header.html" . }}
 <main id="main" class="wrap">
-{{ partial "notice.html" . }}
 <div class="hero">
   <div>
-    <span class="eyebrow">Version 1 · draft</span>
+    <span class="eyebrow">Version 1</span>
     <h1>A signed manifest for every release.</h1>
     <p class="lede">Tell consumers what shipped, which file fits their platform, and how to verify it.</p>
     <div class="actions">

--- a/layouts/partials/cli-page.html
+++ b/layouts/partials/cli-page.html
@@ -47,7 +47,6 @@
   </aside>
 
   <article class="prose">
-    {{ partial "notice.html" . }}
     <p class="meta">For complete examples, see the <a href="/docs/">guides</a>. This reference is generated from CLI help.</p>
     {{ .Content }}
   </article>

--- a/layouts/partials/doc-page.html
+++ b/layouts/partials/doc-page.html
@@ -44,7 +44,6 @@
     </details>
   </aside>
   <article class="prose">
-    {{ partial "notice.html" . }}
     {{ if eq .RelPermalink "/release/v1/" }}
     <p class="meta">Canonical source: <a href="https://github.com/jdx/packslip/blob/main/docs/spec/packslip.md">docs/spec/packslip.md</a>. Schemas: <a href="/schema/release-v1.json">release/v1</a> and <a href="/schema/releases-v1.json">releases/v1</a>. For examples, start with the <a href="/docs/">guides</a>.</p>
     {{ end }}

--- a/layouts/partials/notice.html
+++ b/layouts/partials/notice.html
@@ -1,1 +1,0 @@
-<p class="notice"><strong>Experimental.</strong> The packslip format and tooling are still changing. Use them for testing until the specification is declared stable.</p>

--- a/static/style.css
+++ b/static/style.css
@@ -225,20 +225,6 @@ pre code { background: none; padding: 0; font-size: inherit; }
 
 .github-link:hover .github-stars { color: var(--accent); }
 
-/* Development notice */
-
-.notice {
-  margin-top: 1.25rem;
-  padding: 0.7rem 1rem;
-  border: 1px solid var(--accent);
-  border-left-width: 4px;
-  border-radius: 6px;
-  background: var(--paper-2);
-  color: var(--ink-2);
-  font-size: 0.95rem;
-}
-.notice strong { color: var(--accent); }
-
 /* Hero */
 
 .hero {
@@ -499,7 +485,6 @@ footer a { color: var(--muted); }
 .skip-link:focus { top: .5rem; }
 a:focus-visible { outline: 2px solid var(--accent); outline-offset: 4px; }
 .doc .prose { max-width: 100%; }
-.doc .notice { margin-top: 0; margin-bottom: 1.5rem; }
 .toc { max-height: calc(100vh - 3rem); overflow-y: auto; }
 .toc ul ul { padding-left: .9rem; }
 .prose :is(h2, h3, h4) { scroll-margin-top: 1.5rem; }


### PR DESCRIPTION
Every page of packslip.dev rendered `layouts/partials/notice.html`:

> **Experimental.** The packslip format and tooling are still changing. Use them for testing until the specification is declared stable.

#62 declared the format stable at version 1 and put that statement into the home page body, README, and CONTRIBUTING. The banner contradicted the page it sat on.

## Changes

- Delete the partial and its calls in `layouts/index.html`, `layouts/partials/doc-page.html`, and `layouts/partials/cli-page.html`.
- Remove the orphaned `.notice` and `.doc .notice` rules from `static/style.css`.
- Change the home-page eyebrow from `Version 1 · draft` to `Version 1`, which made the same stale claim.

Removing rather than rewording: a permanent "Stable" box on every page would be noise. The home page body and the spec's [Stability](https://packslip.dev/release/v1/#stability) section already say it, with a link.

Not touched: `communique.toml` still describes packslip as "a work-in-progress proposal" that "may still change incompatibly". That is the release-notes prompt and deserves its own change.

## Verification

`mise run docs:check` passes: 22 pages built, 754 local links and anchors resolved, quickstart and recipe checks green. The built `public/` pages contain no "Experimental" text and the eyebrow renders as "Version 1".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static Hugo layouts and CSS only; no runtime, auth, or data-handling impact.
> 
> **Overview**
> Aligns packslip.dev with **v1 stability** by removing messaging that still treated the format as experimental.
> 
> The site-wide **Experimental** banner (`layouts/partials/notice.html`) is deleted, along with its includes on the home page, docs, and CLI reference layouts. Related **`.notice`** styles are removed from `static/style.css`. The home hero eyebrow changes from **Version 1 · draft** to **Version 1**.
> 
> No replacement “stable” banner—stability is already stated in page content and the spec.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c49a79eb13bd945f17b3882fd080d5c381017941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->