### PR TITLE
ci: add a final aggregator job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,3 +159,48 @@ jobs:
           test "$COUNT" = 1
           ./target/release/packslip show "$LIST" \
             | jq -e '.predicate.project == "ci.packslip.invalid" and (.predicate.releases | length == 1)' >/dev/null
+
+  # Aggregator that required-status-checks can target. If any upstream job
+  # failed, was cancelled, or was unexpectedly skipped, this step exits non-zero
+  # so the PR is blocked. Lets the branch-protection rule depend on one name
+  # instead of N.
+  final:
+    needs:
+      - signing
+      - test
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions: {}
+    # Run on success or upstream failure but skip when the workflow is cancelled
+    # — `always()` would override `cancel-in-progress` and waste a runner.
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Gate on upstream job results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          # `signing` only runs on a push, where id-token is available; being
+          # skipped on a pull request is expected, not a failure.
+          ALLOW_SKIPPED = {"signing"}
+
+          needs = json.loads(os.environ["NEEDS_JSON"])
+          failed = False
+          for name, data in sorted(needs.items()):
+              result = data.get("result", "unknown")
+              if result == "success" or (result == "skipped" and name in ALLOW_SKIPPED):
+                  print(f"::notice::{name}: {result}")
+              else:
+                  print(f"::error::{name}: {result}")
+                  failed = True
+
+          if failed:
+              print("One or more upstream jobs did not complete successfully.")
+              sys.exit(1)
+
+          print("All CI jobs completed successfully.")
+          PY


### PR DESCRIPTION
Adds the `final` job the other repos in this family use: one aggregator that required-status-checks can target, so branch protection depends on a single name instead of listing every CI job.

It gates on `toJSON(needs)` and annotates each upstream result, failing if any of them is not `success`. `signing` only runs on a push (that's where `id-token` is available), so a skip there is allowed; anything else non-success fails. `if: !cancelled()` rather than `always()`, so a cancelled workflow doesn't burn a runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with no application or security logic; misconfiguration could incorrectly pass or fail PR gates.
> 
> **Overview**
> Adds a **`final`** job at the end of the CI workflow so branch protection can require **one** status check instead of every upstream job name.
> 
> The job depends on **`test`** and **`signing`**, runs when the workflow is not cancelled (`if: !cancelled()`), and uses a short Python step over `toJSON(needs)` to fail if any dependency did not succeed. **`signing`** is treated as an allowed **skip** on pull requests (it only runs on push); any other non-success result fails the gate and blocks the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48476fb1fad7b1c8752ac5417055ef835ec03f98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI/CD**
  - Added a final workflow status check that consolidates signing and test results.
  - Pull requests can now rely on a single CI job for branch-protection checks.
  - Detects failed, cancelled, or unexpectedly skipped jobs and reports the workflow accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->