### PR TITLE
fix(site): render the 404 page the Worker asks for

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Not found — packslip</title>
+<meta name="description" content="No page at this address.">
+<meta name="robots" content="noindex">
+{{ partial "seo.html" . }}
+<link rel="stylesheet" href="/style.css">
+</head>
+<body>
+{{ partial "header.html" . }}
+<main id="main" class="wrap">
+<div class="hero">
+  <div>
+    <span class="eyebrow">404</span>
+    <h1>No page at this address.</h1>
+    <p class="lede">The link may be out of date, or the address mistyped. A release file that is not there answers this way too.</p>
+    <div class="actions">
+      <a class="btn primary" href="/docs/">Read the documentation</a>
+      <a class="btn" href="/">Go to the overview</a>
+    </div>
+  </div>
+</div>
+</main>
+{{ partial "footer.html" . }}
+</body>
+</html>


### PR DESCRIPTION
`wrangler.jsonc` sets `not_found_handling: "404-page"`, and `cloudflare/worker.js` falls through to it for any release path R2 has no object for — "everything else falls through to the site's 404 page". But nothing ever built that page: `layouts/` has no `404.html`, and with no theme configured nothing supplies one, so Hugo never emitted `public/404.html`.

The result is an address with no page answering with an empty body and no content type:

```
$ curl -s -o /dev/null -w '%{http_code} %{content_type} %{size_download}B\n' https://packslip.dev/nope
404  0B
```

GitHub Pages had been substituting its own generic 404, so this only became visible with the move to packslip.dev.

`layouts/404.html` uses the same `seo`, `header`, and `footer` partials and the hero classes the home page already styles, so it needs no CSS. It carries `noindex` and skips the social-image card, which an error page has no use for.

Verified against Hugo 0.165.0, the version `site.yml` pins: `public/404.html` is emitted, renders with no unresolved template syntax, and the release paths keep answering 404 — now with the page attached.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static site template only; no auth, data, or Worker routing logic changes in this diff.
> 
> **Overview**
> **Adds `layouts/404.html`** so Hugo emits `public/404.html`, matching Cloudflare’s `not_found_handling: "404-page"` and the Worker’s fallback for missing release objects.
> 
> The new page reuses existing **`seo`**, **`header`**, and **`footer`** partials and the same hero/button markup as the home page, with **`noindex`** and copy that points visitors to docs and the overview. Unknown URLs should stop returning **404 with an empty body** and instead serve this styled HTML page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9aac4f5f942c41e28ec5a6e97cf0a523f565370d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a custom 404 error page with clear messaging and links to the documentation and overview.
  * Included site-wide header, footer, styling, and SEO elements for a consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->