### PR TITLE
fix(action): pin provenance action dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,7 +222,7 @@ jobs:
       - name: Include the CLI specification
         run: cp packslip.usage.kdl dist/packslip.usage.kdl
       - name: Attest the release files
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: dist/*
       # Keep the release private until its narrative notes and signed packslip

--- a/action.yml
+++ b/action.yml
@@ -248,7 +248,7 @@ runs:
 
     - name: Attest build provenance
       if: inputs.attest == 'true'
-      uses: actions/attest-build-provenance@v2
+      uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
       with:
         subject-path: ${{ steps.files.outputs.files }}
 


### PR DESCRIPTION
GitHub Actions rejects the packslip composite action in repositories that require full-length action SHAs because it references `actions/attest-build-provenance@v2`.

Pin the provenance action to the commit for v2.4.0 in the composite action and packslip release workflow.

Validation: `mise run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pinning only; no changes to attestation inputs, permissions, or packslip signing logic.
> 
> **Overview**
> Repositories that require **full commit SHAs** for third-party Actions were failing when they referenced the packslip composite action, because it still used the floating `actions/attest-build-provenance@v2` reference.
> 
> This PR pins that step to commit `e8998f949152b193b063cb0ec769d69d929409be` (**v2.4.0**) in both **`action.yml`** (composite “Attest build provenance” step) and **`.github/workflows/release.yml`** (“Attest the release files”). Behavior stays the same; only the dependency reference format changes for policy compliance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99daa248a0419d3232cca02a597da1988805d7f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->