### PR TITLE
fix(release): move the major tag through the refs API, and stop faking 206

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,16 +270,22 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          for attempt in 1 2 3; do
-            git tag -f "$MAJOR_TAG" "$GITHUB_SHA"
-            if git push -f origin "refs/tags/$MAJOR_TAG"; then
-              break
-            fi
-            git fetch origin "refs/tags/$MAJOR_TAG:refs/tags/$MAJOR_TAG" -f || true
-            [ "$attempt" -lt 3 ] || exit 1
-          done
+          # Moved through the refs API rather than `git push -f`. A push
+          # sends the tag's tree, and GitHub refuses one from the built-in
+          # token when that tree touches .github/workflows -- which any
+          # release since the last major-tag move may well do, and there is
+          # no `workflows` key in a job's permissions to grant. The commit
+          # is already on the default branch, so updating the ref pushes no
+          # objects and the check does not apply.
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${MAJOR_TAG}" >/dev/null 2>&1; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/git/refs/tags/${MAJOR_TAG}" \
+              -f sha="$GITHUB_SHA" -F force=true >/dev/null
+            echo "moved $MAJOR_TAG to $GITHUB_SHA"
+          else
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/tags/${MAJOR_TAG}" -f sha="$GITHUB_SHA" >/dev/null
+            echo "created $MAJOR_TAG at $GITHUB_SHA"
+          fi
 
   # The release index at https://packslip.dev/.well-known/packslip.json,
   # rebuilt once the release above is public so the action can install the

--- a/cloudflare/worker.js
+++ b/cloudflare/worker.js
@@ -28,8 +28,12 @@ export default {
     const cache = caches.default;
     let response = isList ? undefined : await cache.match(request);
     if (!response) {
+      // Only hand R2 the headers as a range when one was actually asked
+      // for: given a plain GET it still reports a range covering the whole
+      // object, which turned every download into a 206.
+      const wantsRange = request.headers.has("range");
       const object = await env.RELEASES.get(`${env.TOOL}${path}`, {
-        range: request.headers,
+        ...(wantsRange ? { range: request.headers } : {}),
         onlyIf: request.headers,
       });
       if (!object) {
@@ -43,7 +47,17 @@ export default {
       if (isList) {
         headers.set("content-type", "application/json");
       }
-      const status = object.body === undefined ? 304 : object.range ? 206 : 200;
+      const partial = wantsRange && object.range !== undefined;
+      if (partial) {
+        // A 206 without content-range is malformed, and R2 gives the range
+        // back either as an offset and length or as a suffix length.
+        const size = object.size;
+        const suffix = "suffix" in object.range;
+        const offset = suffix ? size - object.range.suffix : object.range.offset ?? 0;
+        const length = suffix ? object.range.suffix : object.range.length ?? size - offset;
+        headers.set("content-range", `bytes ${offset}-${offset + length - 1}/${size}`);
+      }
+      const status = object.body === undefined ? 304 : partial ? 206 : 200;
       response = new Response(
         request.method === "HEAD" || status === 304 ? null : object.body,
         { status, headers },


### PR DESCRIPTION
Two problems the first releases under packslip.dev turned up. They are independent and can be split if either needs longer review.

## The major tag move is not reliable

v1.1.0's release failed here. `release.yml` moves `v1` with `git tag -f` and `git push -f`; a push sends the tag's tree, and GitHub refused it from the built-in token because that tree touches `.github/workflows`:

```
! [remote rejected] v1 -> v1 (refusing to allow a GitHub App to create or update
  workflow `.github/workflows/ci.yml` without `workflows` permission)
```

The three-attempt loop failed three times and the job with it, which also skipped the `list` job that publishes the release index.

**v1.1.1 then did the same move successfully, with this same code.** Both moves started from `5c1cced` and crossed the same `ci.yml` changes (#74, #79), so I cannot tell from outside what differed — a timing effect around what the server considered reachable is the likeliest guess, but it is a guess. `v1` is not stuck today; it points at `a0d434a`.

So this half is hardening, not a live outage. It is still worth doing: a job cannot ask for the `workflows` permission, so as written the step depends on a condition nobody controls, and when it loses it takes the release index down with it. The commit is already on the default branch, so updating the ref pushes no objects and the check does not apply at all. `contents: write` on the job already covers it. The `else` branch creates the tag on a first major release, where there is nothing to move.

## Every download is a 206

`worker.js` passes `request.headers` to `env.RELEASES.get()` as `range` unconditionally. R2 answers a plain GET with a range covering the whole object, so `object.range` is always set and the status is always 206:

```
$ curl -sD- -o /dev/null https://packslip.dev/.well-known/packslip.json
HTTP/2 206
content-type: application/json
```

Three consequences. A 206 with no `content-range` is malformed under RFC 9110, and lenient clients only happen to tolerate it. Genuine range requests are malformed the same way, since `content-range` is never set at all. And `cache.put` runs only `if (!isList && status === 200)`, which never holds — so the `immutable` release files, the whole reason for the long cache lifetime, are read from R2 on every request.

Now the range is only requested when the client asked for one, and `content-range` is set when it did. R2 reports the range as `{offset, length}`, as `{offset}` alone, or as `{suffix}`; all three are handled, checked against `bytes=0-99`, `bytes=500-599`, `bytes=900-`, `bytes=-100`, and a whole-object range.

## Checked

`release.yml` parses and the rewritten step is shellcheck-clean; `node --check` passes on `worker.js`. The tag path cannot be exercised without cutting a release — it runs for real on the next one.
