### PR TITLE
docs: link to the announcement from the landing page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -2,6 +2,10 @@
 title: A signed manifest for every release
 description: Publish the checksums, platforms, executables, and resources for your software in one signed release manifest.
 ---
+Read the [Introducing packslip](https://jdx.dev/posts/2026-09-05-introducing-packslip/)
+announcement for the motivation behind the format and examples of using it
+with mise.
+
 ## What a packslip does
 
 Publish `packslip.sigstore.json` beside your release artifacts. It contains

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -4,10 +4,6 @@ description: Guides and reference for publishing and verifying packslip release 
 ---
 # Documentation
 
-Read the [Introducing packslip](https://jdx.dev/posts/2026-09-05-introducing-packslip/)
-announcement for the motivation behind the format and examples of using it
-with mise.
-
 Choose a path based on whether you publish software, install it, or build
 an integration. For the relationship between configuration, signing, and
 discovery, read [How packslip fits a release](/docs/release-workflow/).

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -4,6 +4,10 @@ description: Guides and reference for publishing and verifying packslip release 
 ---
 # Documentation
 
+Read the [Introducing packslip](https://jdx.dev/posts/2026-09-05-introducing-packslip/)
+announcement for the motivation behind the format and examples of using it
+with mise.
+
 Choose a path based on whether you publish software, install it, or build
 an integration. For the relationship between configuration, signing, and
 discovery, read [How packslip fits a release](/docs/release-workflow/).


### PR DESCRIPTION
Link the landing page to [Introducing packslip](https://jdx.dev/posts/2026-09-05-introducing-packslip/) on jdx.dev, directly below the hero, so visitors can find the format's motivation and mise examples.

Validation: `mise run docs:check` and `git diff --check` pass. Confirmed the announcement URL loads. Browser preview could not run because Chromium's `libnspr4.so` dependency is missing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy and an external link; no product or security behavior changes.
> 
> **Overview**
> The packslip **landing page** (`content/_index.md`) now points readers to the [Introducing packslip](https://jdx.dev/posts/2026-09-05-introducing-packslip/) post right under the hero, before “What a packslip does,” so they can read the format’s motivation and mise usage examples without hunting for it elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b62a8681635dcea5184c3a775272e7546b85caee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->