### PR TITLE
chore(deps): add mr-boxington 1.8.3

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -79,6 +79,48 @@ checksum = "sha256:bdd9cc7837a42389067b2d0df7858d5878ceddef21307c2dd27fa10885fbb
 url = "https://github.com/gohugoio/hugo/releases/download/v0.165.0/hugo_0.165.0_windows-amd64.zip"
 url_api = "https://api.github.com/repos/gohugoio/hugo/releases/assets/511697493"
 
+[[tools.mr-boxington]]
+version = "1.8.3"
+backend = "github:jdx/mr-boxington"
+specifiers = ["1.8.3"]
+
+[tools.mr-boxington."platforms.linux-arm64"]
+checksum = "sha256:c8c0e6ac85afcf17f7143df127337d8ee8fdc22f879bf812081d8958ee253937"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.3/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/546079709"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-arm64-musl"]
+checksum = "sha256:6ce3e6efedc29b52c6daa873f63c98bc757aea89d0e576e3f76a13d3280b48dd"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.3/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/546079710"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-x64"]
+checksum = "sha256:62d122a4103ca286ef86a5c8429d21404f60e795345b8c853a9da0a18ef6dbde"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.3/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/546079720"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-x64-musl"]
+checksum = "sha256:b97fb1c3525fd772610c405b16da051fa6b6e55e499f16818c648414b1b53d2b"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.3/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/546079722"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.macos-arm64"]
+checksum = "sha256:9b01044089551944d12c4412a85dc6788d216c9020aeaf501c405e6a90435596"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.3/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/546079713"
+provenance = "github-attestations"
+provenance_verified = true
+
+[tools.mr-boxington."platforms.windows-x64"]
+checksum = "sha256:24dc00525b058f2bfb0bb17f47e9e50139e7a6a1ffd262616b550159ca53fe03"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.3/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/546079718"
+provenance = "github-attestations"
+
 [[tools.shellcheck]]
 version = "0.11.0"
 backend = "aqua:koalaman/shellcheck"

--- a/mise.toml
+++ b/mise.toml
@@ -1,10 +1,17 @@
+min_version = "2026.8.16"
+
 [tools]
+mr-boxington = "1.8.3"
 # Keep release-note generation reproducible. `latest` is resolved by mise.lock;
 # update the lock deliberately with `mise lock`.
 communique = "latest"
 hugo = "0.165.0"
 shellcheck = "0.11.0"
 usage = "6.6.1"
+
+[wrappers.cargo]
+command = "mbx"
+env = { MBX_CARGO_SHIM_MODE = "1" }
 
 [tasks.build]
 run = "cargo build"


### PR DESCRIPTION
Add mr-boxington 1.8.3 with the transparent Cargo wrapper and the required mise minimum version.

Validation: verified `mbx --version`, checked lockfile versions and release URLs, confirmed unrelated lockfile tools are unchanged, and ran `git diff --check`. Full project CI was not run locally.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile and local dev-tooling only; the cargo wrapper could change how developers run builds under mise but does not alter application or CI workflow logic in this diff.
> 
> **Overview**
> Adds **mr-boxington** `1.8.3` to mise dev tools and locks release URLs/checksums for all supported platforms in `mise.lock`.
> 
> Also bumps the required **mise** version to `2026.8.16` and registers a **`[wrappers.cargo]`** shim that runs `mbx` with `MBX_CARGO_SHIM_MODE=1`, so mise-invoked `cargo` (including the existing `build` task) goes through the transparent Cargo wrapper instead of calling rustc/cargo directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7854a3f37cc48ad5ba6c935fd9358a39c6adb907. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated project tooling requirements and added Cargo command support through the `mr-boxington` tool.
  - No user-facing features or behavior changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->