### PR TITLE
ci: add zizmor GitHub Actions audit

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,20 @@
+name: zizmor
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions: {}
+
+jobs:
+  audit:
+    name: GitHub Actions security analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2


### PR DESCRIPTION
Adds a SHA-pinned zizmor workflow for pushes to main and pull requests. Findings are uploaded to GitHub code scanning via SARIF.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition with scoped permissions and pinned actions; no application or runtime behavior changes.
> 
> **Overview**
> Adds a new **zizmor** workflow that runs GitHub Actions security analysis on pushes to `main` and on pull requests.
> 
> The workflow uses minimal default permissions (`permissions: {}`), grants **`security-events: write`** only on the audit job (for SARIF/code scanning uploads), checks out the repo with **`persist-credentials: false`**, and runs **SHA-pinned** `actions/checkout` and `zizmorcore/zizmor-action`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e43c3e2d9b65f58c6f4dbfb4d11cc895bb58fe9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated security analysis for GitHub Actions workflows on pushes to the main branch and pull requests.
  - Restricted workflow permissions to the minimum required for security reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->